### PR TITLE
Avoid duplicate zCrumbs banner after automatic zBack

### DIFF
--- a/zCLI/subsystems/zWalker/zWalker.py
+++ b/zCLI/subsystems/zWalker/zWalker.py
@@ -346,7 +346,7 @@ class zWalker:
 
             # ⛔ Graceful halt triggered by logic
             if result == "zBack":
-                active_zBlock_dict, zBlock_keys, zKey = self.zCrumbs.handle_zBack()
+                active_zBlock_dict, zBlock_keys, zKey = self.zCrumbs.handle_zBack(show_banner=False)
                 return self.zBlock_loop(active_zBlock_dict, zBlock_keys, zKey)
 
             elif result == "stop":

--- a/zCLI/subsystems/zWalker/zWalker_modules/zCrumbs.py
+++ b/zCLI/subsystems/zWalker/zWalker_modules/zCrumbs.py
@@ -44,7 +44,7 @@ class zCrumbs:
         zBlock_crumbs.append(zKey)
         logger.debug("\nCurrent zTrail: %s", zBlock_crumbs)
 
-    def handle_zBack(self):
+    def handle_zBack(self, show_banner=True):
         self.walker.display.handle({
             "event": "sysmsg",
             "label": "zBack",
@@ -97,7 +97,8 @@ class zCrumbs:
             if trail:
                 trail.pop()
                 logger.debug("parent trail (post second pop): %s", trail)
-        self.walker.display.handle({"event": "zCrumbs"})  # Aesthetic
+        if show_banner and getattr(self.walker, "display", None):
+            self.walker.display.handle({"event": "zCrumbs"})  # Aesthetic
 
         if trail == [] and active_zCrumb == original_zCrumb:
             logger.debug("Root scope reached; crumb cleared but scope preserved.")


### PR DESCRIPTION
## Summary
- add an optional flag to `zCrumbs.handle_zBack` so callers can suppress the zCrumbs banner
- call `handle_zBack` with the suppression flag when returning from `zWalker` loops to avoid double breadcrumb output

## Testing
- pytest tests/test_walker.py

------
https://chatgpt.com/codex/tasks/task_b_68e41817fbd0832bbe9f244001ffc3cb