### PR TITLE
Fix zPath base path calculation for zLink resolution

### DIFF
--- a/zCLI/subsystems/zParser_modules/zParser_zPath.py
+++ b/zCLI/subsystems/zParser_modules/zParser_zPath.py
@@ -61,14 +61,19 @@ def zPath_decoder(zSession, zPath=None, zType=None, display=None):
         logger.info("\nzPath_2_zFile: %s", zPath_2_zFile)
 
         # Extract file name (last 2 parts, or just last part if only 2 total)
-        if len(zPath_2_zFile) == 2:
+        if len(zPath_2_zFile) == 1:
+            zFileName = zPath_2_zFile[0]
+            filename_parts_count = 1
+        elif len(zPath_2_zFile) == 2:
             zFileName = zPath_2_zFile[-1]  # Just the filename part
+            filename_parts_count = 1
         else:
             zFileName = ".".join(zPath_2_zFile[-2:])  # Last 2 parts
+            filename_parts_count = 2
         logger.info("zFileName: %s", zFileName)
 
         # Remaining parts (before filename)
-        zRelPath_parts = zPath_parts[:-2]
+        zRelPath_parts = zPath_2_zFile[:-filename_parts_count]
         logger.info("zRelPath_parts: %s", zRelPath_parts)
 
         # Fork on symbol


### PR DESCRIPTION
## Summary
- ensure zPath decoding trims the correct number of path segments when building the base path
- fix zLink resolution so UI files like `ui.zoloP2` resolve to the correct directory

## Testing
- pytest *(fails: pre-existing NameError: name 'self' is not defined in zLoader)*

------
https://chatgpt.com/codex/tasks/task_b_68e423413e60832b82da44aecd7d919d