### PR TITLE
Move CLI main module to package root

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,8 +100,8 @@ dev = [
 # -----------------------------------------------------------------------------
 # This creates the 'zolo-zcli' command that users can run from terminal
 [project.scripts]
-# When user types 'zolo-zcli', it calls the main() function in zCLI.zCore.main
-zolo-zcli = "zCLI.zCore.main:main"
+# When user types 'zolo-zcli', it calls the main() function in zCLI.main
+zolo-zcli = "zCLI.main:main"
 
 # -----------------------------------------------------------------------------
 # PROJECT URLs

--- a/zCLI/main.py
+++ b/zCLI/main.py
@@ -1,12 +1,7 @@
-# zCLI/zCore/main.py — Main Entry Point for zCLI Core
+# zCLI/main.py — Main Entry Point for zCLI Core
 # ───────────────────────────────────────────────────────────────
 
-import sys
-import os
 import argparse
-
-# Add project root to path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
 
 from zCLI.zCore.zCLI import zCLI
 from zCLI.version import get_version, get_package_info
@@ -14,20 +9,20 @@ from zCLI.utils.logger import logger
 
 def main():
     """Main entry point for zolo-zcli command."""
-    
+
     # Set up argument parser
     parser = argparse.ArgumentParser(
         description='Zolo zCLI Framework - YAML-driven CLI for interactive applications',
         prog='zolo-zcli'
     )
-    parser.add_argument('--shell', action='store_true', 
+    parser.add_argument('--shell', action='store_true',
                        help='Start zCLI shell mode')
-    parser.add_argument('--version', action='version', 
+    parser.add_argument('--version', action='version',
                        version=f'zolo-zcli {get_version()}')
-    
+
     # Parse arguments
     args = parser.parse_args()
-    
+
     if args.shell:
         # Shell mode - start shell
         logger.info("Starting zCLI Shell mode...")


### PR DESCRIPTION
## Summary
- relocate the CLI entry point module from `zCLI/zCore` into the package root
- update the project script declaration to reference the new module path

## Testing
- pytest *(fails: NameError: name 'self' is not defined in zCLI/subsystems/zLoader.py during CRUD tests)*

------
https://chatgpt.com/codex/tasks/task_b_68e4a5da4a1c832bbbb34e854b5b0142