### PR TITLE
Refactor logging initialization and propagation

### DIFF
--- a/tests/utils/zFunc_Example.py
+++ b/tests/utils/zFunc_Example.py
@@ -1,6 +1,8 @@
 import os
 import sys
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 from zCLI.subsystems.zDisplay import handle_zDisplay
 
 def Func_Example(session=None):

--- a/zCLI/setup.py
+++ b/zCLI/setup.py
@@ -15,7 +15,9 @@ This runs automatically on first import of zConfig.
 
 import os
 from pathlib import Path
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 
 
 def ensure_config_directories():

--- a/zCLI/subsystems/zConfig.py
+++ b/zCLI/subsystems/zConfig.py
@@ -22,7 +22,9 @@ Philosophy: Everything is a zVaFile (including config!)
 """
 
 import os
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 from zCLI.subsystems.zConfig_modules import ZConfigPaths, ConfigLoader
 from zCLI.subsystems.zConfig_modules.machine_config import MachineConfig
 

--- a/zCLI/subsystems/zConfig_modules/config_loader.py
+++ b/zCLI/subsystems/zConfig_modules/config_loader.py
@@ -8,7 +8,9 @@ Loads config from multiple sources and merges them with priority.
 import os
 import yaml
 from pathlib import Path
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 
 
 class ConfigLoader:

--- a/zCLI/subsystems/zConfig_modules/config_paths.py
+++ b/zCLI/subsystems/zConfig_modules/config_paths.py
@@ -8,7 +8,9 @@ Uses platformdirs for OS-native paths with dotfile fallback.
 import platform
 from pathlib import Path
 from platformdirs import user_config_dir, site_config_dir, user_data_dir, user_cache_dir
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 
 
 class ZConfigPaths:

--- a/zCLI/subsystems/zConfig_modules/machine_config.py
+++ b/zCLI/subsystems/zConfig_modules/machine_config.py
@@ -12,7 +12,9 @@ import socket
 import shutil
 import yaml
 from pathlib import Path
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 
 
 class MachineConfig:

--- a/zCLI/subsystems/zData/__init__.py
+++ b/zCLI/subsystems/zData/__init__.py
@@ -8,6 +8,10 @@ from .zData_modules.infrastructure import (
     zTables, zDataConnect, zEnsureTables, resolve_source, build_order_clause,
     handle_zData  # Legacy handle_zData with zCRUD_Preped signature
 )
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
 from .zData_modules.migration import (
     ZMigrate, auto_migrate_schema, detect_schema_changes
 )
@@ -18,7 +22,7 @@ def handle_zCRUD(zRequest, walker=None):
     Legacy handle_zCRUD function - delegates to handle_zData.
     Kept for backward compatibility with existing code.
     """
-    from zCLI.utils.logger import logger
+
     from zCLI.subsystems.zLoader import handle_zLoader
     from zCLI.subsystems.zDisplay import handle_zDisplay
     

--- a/zCLI/subsystems/zData/zData.py
+++ b/zCLI/subsystems/zData/zData.py
@@ -15,7 +15,9 @@
 # - Schema: Schema parsing and validation
 # ----------------------------------------------------------------
 
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 from zCLI.subsystems.zDisplay import handle_zDisplay, Colors, print_line
 from zCLI.subsystems.zParser import parse_dotted_path, ZParser
 from zCLI.subsystems.zLoader import handle_zLoader

--- a/zCLI/subsystems/zData/zData_modules/backends/adapter_factory.py
+++ b/zCLI/subsystems/zData/zData_modules/backends/adapter_factory.py
@@ -5,7 +5,9 @@
 # Supports dynamic registration of custom adapters for extensibility.
 # ----------------------------------------------------------------
 
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 
 
 class AdapterFactory:

--- a/zCLI/subsystems/zData/zData_modules/backends/base_adapter.py
+++ b/zCLI/subsystems/zData/zData_modules/backends/base_adapter.py
@@ -7,7 +7,9 @@
 # ----------------------------------------------------------------
 
 from abc import ABC, abstractmethod
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 
 
 class BaseDataAdapter(ABC):

--- a/zCLI/subsystems/zData/zData_modules/backends/csv_adapter.py
+++ b/zCLI/subsystems/zData/zData_modules/backends/csv_adapter.py
@@ -9,7 +9,9 @@
 import os
 from pathlib import Path
 from .base_adapter import BaseDataAdapter
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 
 try:
     import pandas as pd

--- a/zCLI/subsystems/zData/zData_modules/backends/sqlite_adapter.py
+++ b/zCLI/subsystems/zData/zData_modules/backends/sqlite_adapter.py
@@ -8,7 +8,9 @@
 
 import sqlite3
 from .base_adapter import BaseDataAdapter
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 
 
 class SQLiteAdapter(BaseDataAdapter):

--- a/zCLI/subsystems/zData/zData_modules/infrastructure.py
+++ b/zCLI/subsystems/zData/zData_modules/infrastructure.py
@@ -11,7 +11,9 @@
 # ----------------------------------------------------------------
 
 import re
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 from zCLI.subsystems.zDisplay import handle_zDisplay
 from zCLI.subsystems.zFunc import handle_zFunc
 from zCLI.subsystems.zUtils import ZUtils

--- a/zCLI/subsystems/zData/zData_modules/migration.py
+++ b/zCLI/subsystems/zData/zData_modules/migration.py
@@ -14,7 +14,9 @@ Handles:
 Future: DROP COLUMN, RENAME, TYPE changes, indexes, etc.
 """
 
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 
 # ═══════════════════════════════════════════════════════════════════
 # Ghost Migration Table Schema for RGB Tracking

--- a/zCLI/subsystems/zData/zData_modules/operations/crud_alter.py
+++ b/zCLI/subsystems/zData/zData_modules/operations/crud_alter.py
@@ -23,7 +23,9 @@ Table Recreation Pattern (for old SQLite):
 4. ALTER TABLE new_table RENAME TO old_table
 """
 
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 from zCLI.subsystems.zDisplay import handle_zDisplay
 import sqlite3
 import datetime

--- a/zCLI/subsystems/zData/zData_modules/operations/crud_create.py
+++ b/zCLI/subsystems/zData/zData_modules/operations/crud_create.py
@@ -1,7 +1,9 @@
 # zCLI/crud/crud_create.py — Create Operations
 # ───────────────────────────────────────────────────────────────
 
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 from zCLI.subsystems.zDisplay import handle_zDisplay
 from zCLI.subsystems.zData.zData_modules.infrastructure import resolve_source
 from .crud_validator import RuleValidator, display_validation_errors

--- a/zCLI/subsystems/zData/zData_modules/operations/crud_delete.py
+++ b/zCLI/subsystems/zData/zData_modules/operations/crud_delete.py
@@ -1,7 +1,9 @@
 # zCLI/crud/crud_delete.py — Delete, Truncate, and List Operations
 # ───────────────────────────────────────────────────────────────
 
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 from zCLI.subsystems.zDisplay import handle_zDisplay
 from .crud_where import build_where_clause
 

--- a/zCLI/subsystems/zData/zData_modules/operations/crud_join.py
+++ b/zCLI/subsystems/zData/zData_modules/operations/crud_join.py
@@ -11,7 +11,9 @@ Supports:
 - Multi-table queries with proper field aliasing
 """
 
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 from .crud_where import build_where_clause as build_where_with_tables  # Re-export for compatibility
 
 

--- a/zCLI/subsystems/zData/zData_modules/operations/crud_read.py
+++ b/zCLI/subsystems/zData/zData_modules/operations/crud_read.py
@@ -1,7 +1,9 @@
 # zCLI/crud/crud_read.py — Read and Search Operations
 # ───────────────────────────────────────────────────────────────
 
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 from zCLI.subsystems.zDisplay import handle_zDisplay
 from zCLI.subsystems.zSession import zSession
 from zCLI.subsystems.zData.zData_modules.infrastructure import build_order_clause

--- a/zCLI/subsystems/zData/zData_modules/operations/crud_update.py
+++ b/zCLI/subsystems/zData/zData_modules/operations/crud_update.py
@@ -1,7 +1,9 @@
 # zCLI/crud/crud_update.py — Update Operations
 # ───────────────────────────────────────────────────────────────
 
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 from zCLI.subsystems.zDisplay import handle_zDisplay
 from .crud_where import build_where_clause
 

--- a/zCLI/subsystems/zData/zData_modules/operations/crud_upsert.py
+++ b/zCLI/subsystems/zData/zData_modules/operations/crud_upsert.py
@@ -31,7 +31,9 @@ Examples:
     }
 """
 
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 from zCLI.subsystems.zDisplay import handle_zDisplay
 
 

--- a/zCLI/subsystems/zData/zData_modules/operations/crud_validator.py
+++ b/zCLI/subsystems/zData/zData_modules/operations/crud_validator.py
@@ -13,7 +13,9 @@ Supports:
 """
 
 import re
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 from zCLI.subsystems.zDisplay import handle_zDisplay
 
 

--- a/zCLI/subsystems/zData/zData_modules/operations/crud_where.py
+++ b/zCLI/subsystems/zData/zData_modules/operations/crud_where.py
@@ -39,7 +39,9 @@ Examples:
     # SQL: WHERE (status = ? OR priority >= ?)
 """
 
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 
 
 def build_where_clause(filters, table_prefix=None):

--- a/zCLI/subsystems/zData/zData_modules/schema/field_parser.py
+++ b/zCLI/subsystems/zData/zData_modules/schema/field_parser.py
@@ -7,7 +7,9 @@
 # - parse_type(): Parse type strings with defaults and legacy markers
 # ----------------------------------------------------------------
 
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 
 
 def parse_type(raw_type):

--- a/zCLI/subsystems/zData/zData_modules/schema/fk_resolver.py
+++ b/zCLI/subsystems/zData/zData_modules/schema/fk_resolver.py
@@ -7,7 +7,9 @@
 # ----------------------------------------------------------------
 
 import sqlite3
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 from zCLI.subsystems.zParser import handle_zRef
 from zCLI.subsystems.zDisplay import Colors, print_line
 

--- a/zCLI/subsystems/zData/zData_modules/schema/sql_generator.py
+++ b/zCLI/subsystems/zData/zData_modules/schema/sql_generator.py
@@ -7,7 +7,9 @@
 # - map_schema_type(): Map schema types to SQL types
 # ----------------------------------------------------------------
 
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 from zCLI.subsystems.zDisplay import Colors, print_line
 
 

--- a/zCLI/subsystems/zDialog.py
+++ b/zCLI/subsystems/zDialog.py
@@ -17,7 +17,9 @@ Key Responsibilities:
 - Submission handling (dict or string expressions)
 """
 
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 from zCLI.subsystems.zDisplay import handle_zDisplay
 from zCLI.subsystems.zSession import zSession
 from zCLI.subsystems.zDialog_modules import create_dialog_context, handle_submit

--- a/zCLI/subsystems/zDialog_modules/dialog_context.py
+++ b/zCLI/subsystems/zDialog_modules/dialog_context.py
@@ -3,7 +3,9 @@
 Context management for zDialog - Handles context creation and placeholder injection
 """
 
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 
 
 def create_dialog_context(model, fields, zConv=None):

--- a/zCLI/subsystems/zDialog_modules/dialog_submit.py
+++ b/zCLI/subsystems/zDialog_modules/dialog_submit.py
@@ -3,7 +3,9 @@
 Submission handling for zDialog - Processes onSubmit expressions
 """
 
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 from zCLI.subsystems.zDisplay import handle_zDisplay
 from .dialog_context import inject_placeholders
 

--- a/zCLI/subsystems/zDisplay.py
+++ b/zCLI/subsystems/zDisplay.py
@@ -20,7 +20,9 @@ Key Responsibilities:
 
 import json
 import asyncio
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 from zCLI.subsystems.zSocket import broadcast
 from zCLI.subsystems.zDisplay_modules import (
     normalize_field_def, pick_fk_value, split_required,

--- a/zCLI/subsystems/zDisplay_modules/display_forms.py
+++ b/zCLI/subsystems/zDisplay_modules/display_forms.py
@@ -3,7 +3,9 @@
 Form rendering for zDisplay - Interactive form collection (render_zConv)
 """
 
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 from .display_input import handle_input as handle_zInput
 
 

--- a/zCLI/subsystems/zDisplay_modules/display_input.py
+++ b/zCLI/subsystems/zDisplay_modules/display_input.py
@@ -3,7 +3,9 @@
 Input handling for zDisplay - User input collection (now uses InputFactory)
 """
 
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 from .input import InputFactory
 
 

--- a/zCLI/subsystems/zDisplay_modules/display_render.py
+++ b/zCLI/subsystems/zDisplay_modules/display_render.py
@@ -4,7 +4,9 @@ Rendering functions for zDisplay - Headers, menus, tables, markers, sessions
 """
 
 import json
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 from .display_colors import Colors, print_line
 
 

--- a/zCLI/subsystems/zDisplay_modules/display_render.py.fixed
+++ b/zCLI/subsystems/zDisplay_modules/display_render.py.fixed
@@ -4,7 +4,9 @@ Rendering functions for zDisplay - Headers, menus, tables, markers, sessions
 """
 
 import json
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 from .display_colors import Colors, print_line
 
 

--- a/zCLI/subsystems/zDisplay_modules/input/input_adapter.py
+++ b/zCLI/subsystems/zDisplay_modules/input/input_adapter.py
@@ -3,7 +3,9 @@
 Input adapter base class and factory for multi-mode input collection
 """
 
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 
 
 class InputMode:

--- a/zCLI/subsystems/zDisplay_modules/input/input_rest.py
+++ b/zCLI/subsystems/zDisplay_modules/input/input_rest.py
@@ -6,7 +6,9 @@ TODO: Implement when REST API wrapper is created
 """
 
 from .input_adapter import InputAdapter
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 
 
 class RESTInput(InputAdapter):

--- a/zCLI/subsystems/zDisplay_modules/input/input_terminal.py
+++ b/zCLI/subsystems/zDisplay_modules/input/input_terminal.py
@@ -4,7 +4,9 @@ Terminal input adapter - Blocking input() calls (current implementation)
 """
 
 from .input_adapter import InputAdapter
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 
 
 class TerminalInput(InputAdapter):

--- a/zCLI/subsystems/zDisplay_modules/input/input_websocket.py
+++ b/zCLI/subsystems/zDisplay_modules/input/input_websocket.py
@@ -8,7 +8,9 @@ TODO: Implement when zCloud frontend is ready
 import json
 import asyncio
 from .input_adapter import InputAdapter
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 
 
 class WebSocketInput(InputAdapter):

--- a/zCLI/subsystems/zDisplay_modules/output/output_adapter.py
+++ b/zCLI/subsystems/zDisplay_modules/output/output_adapter.py
@@ -3,7 +3,9 @@
 Output adapter base class and factory for multi-mode rendering
 """
 
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 
 
 class OutputMode:

--- a/zCLI/subsystems/zDisplay_modules/output/output_rest.py
+++ b/zCLI/subsystems/zDisplay_modules/output/output_rest.py
@@ -6,7 +6,9 @@ TODO: Implement when REST API wrapper is created
 """
 
 from .output_adapter import OutputAdapter
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 
 
 class RESTOutput(OutputAdapter):

--- a/zCLI/subsystems/zDisplay_modules/output/output_websocket.py
+++ b/zCLI/subsystems/zDisplay_modules/output/output_websocket.py
@@ -8,7 +8,9 @@ TODO: Implement when zCloud frontend is ready
 import json
 import asyncio
 from .output_adapter import OutputAdapter
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 
 
 class WebSocketOutput(OutputAdapter):

--- a/zCLI/subsystems/zExport.py
+++ b/zCLI/subsystems/zExport.py
@@ -20,7 +20,9 @@ Example Usage:
 
 import yaml
 from pathlib import Path
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 
 
 class ZExport:

--- a/zCLI/subsystems/zFunc.py
+++ b/zCLI/subsystems/zFunc.py
@@ -1,7 +1,9 @@
 import os
 import importlib.util
 
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 from zCLI.subsystems.zDisplay import handle_zDisplay, handle_zInput
 from zCLI.subsystems.zSession import zSession
 

--- a/zCLI/subsystems/zLoader.py
+++ b/zCLI/subsystems/zLoader.py
@@ -18,7 +18,9 @@ Key Responsibilities:
 NOT for external files (that's zOpen).
 """
 
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 from zCLI.subsystems.zSession import zSession
 from zCLI.subsystems.zDisplay import handle_zDisplay
 from zCLI.subsystems.zLoader_modules import SmartCache, LoadedCache, load_file_raw
@@ -134,7 +136,7 @@ class ZLoader:
         loaded_key = f"parsed:{zPath_key}"
         loaded = self.loaded_cache.get(loaded_key)
         if loaded is not None:
-            self.display.handle({
+            handle_zDisplay({
                 "event": "sysmsg",
                 "label": "zLoader return (loaded)",
                 "style": "~",
@@ -149,7 +151,7 @@ class ZLoader:
         cache_key = f"parsed:{zPath_key}"
         cached = self.cache.get(cache_key, filepath=zFilePath_identified)
         if cached is not None:
-            self.display.handle({
+            handle_zDisplay({
                 "event": "sysmsg",
                 "label": "zLoader return (cached)",
                 "style": "~",
@@ -202,7 +204,7 @@ def handle_zLoader(zPath=None, walker=None, session=None, zcli=None):
     Returns:
         Parsed file content (dict) or "error" on failure
     """
-    self.display.handle({
+    handle_zDisplay({
         "event": "sysmsg",
         "label": "zLoader",
         "style": "full",
@@ -249,7 +251,7 @@ def handle_zLoader(zPath=None, walker=None, session=None, zcli=None):
     result = parse_file_content(zFile_raw, zFile_extension)
     logger.debug("zLoader parse result:\n%s", result)
 
-    self.display.handle({
+    handle_zDisplay({
         "event": "sysmsg",
         "label": "zLoader return",
         "style": "~",

--- a/zCLI/subsystems/zLoader_modules/loaded_cache.py
+++ b/zCLI/subsystems/zLoader_modules/loaded_cache.py
@@ -10,7 +10,9 @@ Unlike the automatic 'files' cache, entries here:
 """
 
 import time
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 
 
 class LoadedCache:

--- a/zCLI/subsystems/zLoader_modules/loader_io.py
+++ b/zCLI/subsystems/zLoader_modules/loader_io.py
@@ -3,7 +3,9 @@
 File I/O operations for zLoader - Raw file reading from disk
 """
 
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 from zCLI.subsystems.zDisplay import handle_zDisplay
 
 

--- a/zCLI/subsystems/zLoader_modules/smart_cache.py
+++ b/zCLI/subsystems/zLoader_modules/smart_cache.py
@@ -6,7 +6,9 @@ Smart Cache - Unified caching with automatic invalidation and LRU eviction
 import os
 import time
 from collections import OrderedDict
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 
 
 class SmartCache:

--- a/zCLI/subsystems/zOpen.py
+++ b/zCLI/subsystems/zOpen.py
@@ -3,7 +3,9 @@
 """Core zOpen handler for file and URL opening operations."""
 
 from urllib.parse import urlparse
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 from zCLI.subsystems.zDisplay import handle_zDisplay
 from zCLI.subsystems.zSession import zSession
 

--- a/zCLI/subsystems/zParser.py
+++ b/zCLI/subsystems/zParser.py
@@ -2,7 +2,9 @@
 # ───────────────────────────────────────────────────────────────
 """Core zParser handler for path resolution, command parsing, file parsing, and utilities."""
 
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 from zCLI.subsystems.zSession import zSession
 
 # Import zParser modules from registry

--- a/zCLI/subsystems/zParser_modules/zParser_file.py
+++ b/zCLI/subsystems/zParser_modules/zParser_file.py
@@ -14,7 +14,9 @@
 
 import yaml
 import json
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 
 
 def parse_file_content(raw_content, file_extension=None):

--- a/zCLI/subsystems/zParser_modules/zParser_utils.py
+++ b/zCLI/subsystems/zParser_modules/zParser_utils.py
@@ -5,7 +5,9 @@
 import os
 import json
 import yaml
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 from zCLI.subsystems.zDisplay import handle_zDisplay
 
 

--- a/zCLI/subsystems/zParser_modules/zParser_zPath.py
+++ b/zCLI/subsystems/zParser_modules/zParser_zPath.py
@@ -3,7 +3,9 @@
 """zPath resolution and file discovery functionality."""
 
 import os
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 from zCLI.subsystems.zDisplay import handle_zDisplay
 
 

--- a/zCLI/subsystems/zParser_modules/zParser_zVaFile.py
+++ b/zCLI/subsystems/zParser_modules/zParser_zVaFile.py
@@ -18,7 +18,9 @@
 # - validate_schema_structure(): Schema file structure validation
 # ----------------------------------------------------------------
 
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 from zCLI.subsystems.zDisplay import Colors, print_line
 
 

--- a/zCLI/subsystems/zSession.py
+++ b/zCLI/subsystems/zSession.py
@@ -1,5 +1,7 @@
 import requests
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 from zCLI.subsystems.zDisplay import handle_zDisplay
 
 def create_session(machine_config=None):

--- a/zCLI/subsystems/zShell.py
+++ b/zCLI/subsystems/zShell.py
@@ -7,7 +7,9 @@ This module serves as the main handler for zShell functionality,
 delegating to specialized modules within zShell_modules/.
 """
 
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 
 # Import specialized modules from zShell_modules registry
 from .zShell_modules.zShell_interactive import InteractiveShell as InteractiveShell_func, launch_zCLI_shell as launch_zCLI_shell_func
@@ -33,14 +35,18 @@ class ZShell:
             zcli: Parent zCLI instance
         """
         self.zcli = zcli
-        self.logger = logger
+        parent_logger = getattr(zcli, "logger", None)
+        if parent_logger:
+            self.logger = parent_logger.getChild(self.__class__.__name__)
+        else:
+            self.logger = logger
         
         # Initialize shell components
         self.interactive = InteractiveShell_func(zcli)
         self.executor = CommandExecutor_func(zcli)
         self.help_system = HelpSystem_func()
         
-        logger.debug("zShell handler initialized")
+        self.logger.debug("zShell handler initialized")
     
     def run_shell(self):
         """Run shell mode."""

--- a/zCLI/subsystems/zShell_modules/zShell_interactive.py
+++ b/zCLI/subsystems/zShell_modules/zShell_interactive.py
@@ -1,7 +1,9 @@
 # zCLI/zCore/Shell.py — Interactive Shell Mode
 # ───────────────────────────────────────────────────────────────
 
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 from .zShell_help import HelpSystem
 from .zShell_executor import CommandExecutor
 
@@ -26,14 +28,18 @@ class InteractiveShell:
             zcli: Parent zCLI instance
         """
         self.zcli = zcli
-        self.logger = logger
+        parent_logger = getattr(zcli, "logger", None)
+        if parent_logger:
+            self.logger = parent_logger.getChild(self.__class__.__name__)
+        else:
+            self.logger = logger
         self.executor = CommandExecutor(zcli)
         self.help_system = HelpSystem()
         self.running = False
     
     def run(self):
         """Main shell loop - handles user input and command execution."""
-        logger.info("Starting zCLI shell...")
+        self.logger.info("Starting zCLI shell...")
         
         # Show welcome message
         print(self.help_system.get_welcome_message())
@@ -69,10 +75,10 @@ class InteractiveShell:
                 break
             
             except Exception as e:
-                logger.error("Shell error: %s", e)
+                self.logger.error("Shell error: %s", e)
                 print(f"[X] Error: {e}")
         
-        logger.info("Exiting zCLI shell...")
+        self.logger.info("Exiting zCLI shell...")
     
     def _handle_special_commands(self, command):
         """

--- a/zCLI/subsystems/zSocket.py
+++ b/zCLI/subsystems/zSocket.py
@@ -9,7 +9,9 @@ import os
 from websockets.server import serve  # ✅ New API
 from websockets.legacy.server import WebSocketServerProtocol
 from websockets import exceptions as ws_exceptions
-from zCLI.utils.logger import logger  # ✅ Central logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)  # ✅ Central logger
 
 # lazy import for CLI handlers to avoid heavy imports during module load
 

--- a/zCLI/subsystems/zUtils.py
+++ b/zCLI/subsystems/zUtils.py
@@ -10,6 +10,10 @@ import platform
 import subprocess
 import sys
 
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
 
 class ZUtils:
     """

--- a/zCLI/subsystems/zWalker/zWalker_modules/zCrumbs.py
+++ b/zCLI/subsystems/zWalker/zWalker_modules/zCrumbs.py
@@ -1,4 +1,6 @@
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 from zCLI.subsystems.zSession import zSession
 from zCLI.subsystems.zDisplay import handle_zDisplay
 

--- a/zCLI/subsystems/zWalker/zWalker_modules/zDispatch.py
+++ b/zCLI/subsystems/zWalker/zWalker_modules/zDispatch.py
@@ -1,4 +1,6 @@
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 from zCLI.subsystems.zSession import zSession
 from zCLI.subsystems.zDialog import handle_zDialog
 from zCLI.subsystems.zFunc import handle_zFunc

--- a/zCLI/subsystems/zWalker/zWalker_modules/zLink.py
+++ b/zCLI/subsystems/zWalker/zWalker_modules/zLink.py
@@ -1,4 +1,6 @@
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 from zCLI.subsystems.zSession import zSession
 from zCLI.subsystems.zDisplay import handle_zDisplay
 from zCLI.subsystems.zParser import zExpr_eval

--- a/zCLI/subsystems/zWalker/zWalker_modules/zMenu.py
+++ b/zCLI/subsystems/zWalker/zWalker_modules/zMenu.py
@@ -1,4 +1,6 @@
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 from zCLI.subsystems.zSession import zSession
 from zCLI.subsystems.zDisplay import handle_zDisplay, handle_zInput
 

--- a/zCLI/subsystems/zWizard.py
+++ b/zCLI/subsystems/zWizard.py
@@ -1,4 +1,6 @@
-from zCLI.utils.logger import logger
+from zCLI.utils.logger import get_logger
+
+logger = get_logger(__name__)
 from zCLI.subsystems.zDisplay import handle_zDisplay
 from zCLI.subsystems.zWalker.zWalker_modules.zDispatch import handle_zDispatch
 from zCLI.subsystems.zSession import zSession

--- a/zCLI/utils/logger.py
+++ b/zCLI/utils/logger.py
@@ -1,155 +1,107 @@
-# zCLI/utils/logger.py — Self-contained logging for zCLI package
-# ───────────────────────────────────────────────────────────────
-"""Self-contained logging module for zCLI package."""
+"""Self-contained logging utilities for the zCLI package."""
+
+from __future__ import annotations
 
 import logging
 import sys
-from typing import Optional
+from typing import Optional, TextIO
 
 
-# ANSI color codes for log formatting
 class LogColors:
-    """Colors specifically for system logs."""
+    """ANSI colors specifically for system logs."""
+
     LOG_PREFIX = "\033[38;5;248m"  # Medium gray for log metadata (readable on dark bg)
-    DEBUG = "\033[38;5;250m"        # Light gray for debug
-    INFO = "\033[38;5;39m"          # Bright blue for info
-    WARNING = "\033[38;5;214m"      # Orange for warnings
-    ERROR = "\033[38;5;196m"        # Bright red for errors
-    CRITICAL = "\033[38;5;201m"     # Magenta for critical
+    DEBUG = "\033[38;5;250m"  # Light gray for debug
+    INFO = "\033[38;5;39m"  # Bright blue for info
+    WARNING = "\033[38;5;214m"  # Orange for warnings
+    ERROR = "\033[38;5;196m"  # Bright red for errors
+    CRITICAL = "\033[38;5;201m"  # Magenta for critical
     RESET = "\033[0m"
     BOLD = "\033[1m"
 
 
 class ColoredFormatter(logging.Formatter):
-    """
-    Custom formatter that adds visual markers and colors to log messages.
-    Distinguishes system logs from regular terminal output.
-    """
-    
-    # Log level to color mapping
+    """Formatter that adds colors and metadata markers to log messages."""
+
     LEVEL_COLORS = {
-        'DEBUG': LogColors.DEBUG,
-        'INFO': LogColors.INFO,
-        'WARNING': LogColors.WARNING,
-        'ERROR': LogColors.ERROR,
-        'CRITICAL': LogColors.CRITICAL,
+        "DEBUG": LogColors.DEBUG,
+        "INFO": LogColors.INFO,
+        "WARNING": LogColors.WARNING,
+        "ERROR": LogColors.ERROR,
+        "CRITICAL": LogColors.CRITICAL,
     }
-    
-    def format(self, record):
-        """Format log record with colors and visual markers."""
-        # Get color for this log level
+
+    def format(self, record: logging.LogRecord) -> str:  # noqa: D401 - see class docstring
         level_color = self.LEVEL_COLORS.get(record.levelname, LogColors.INFO)
-        
-        # Format timestamp and metadata in medium gray (readable on dark backgrounds)
         timestamp = self.formatTime(record, self.datefmt)
         metadata = f"{LogColors.LOG_PREFIX}[{timestamp}]{LogColors.RESET}"
-        
-        # Format log level with its color and bold
         level = f"{level_color}{LogColors.BOLD}[{record.levelname}]{LogColors.RESET}"
-        
-        # Format location in medium gray (readable on dark backgrounds)
         location = f"{LogColors.LOG_PREFIX}{record.name}:{record.lineno}{LogColors.RESET}"
-        
-        # Message in level color
         message = f"{level_color}{record.getMessage()}{LogColors.RESET}"
-        
-        # Add visual marker for system logs
         marker = f"{LogColors.LOG_PREFIX}●{LogColors.RESET}"
-        
-        # Combine: ● [timestamp] [LEVEL] location | message
         return f"{marker} {metadata} {level} {location} | {message}"
 
 
-class zCLILogger:
-    """
-    Self-contained logger for zCLI package.
-    Provides basic logging functionality without external dependencies.
-    """
-    
-    def __init__(self, name: str = "zCLI"):
-        self.name = name
-        self.logger = logging.getLogger(name)
-        self._setup_logger()
-    
-    def _setup_logger(self):
-        """Setup the logger with colored formatter and visual markers."""
-        if not self.logger.handlers:
-            # Create console handler
-            handler = logging.StreamHandler(sys.stdout)
-            
-            # Create colored formatter with visual markers
-            formatter = ColoredFormatter(
-                datefmt='%H:%M:%S'  # Shorter time format for cleaner logs
-            )
-            handler.setFormatter(formatter)
-            
-            # Add handler to logger
-            self.logger.addHandler(handler)
-            
-            # Set default level
-            self.logger.setLevel(logging.INFO)
-    
-    def debug(self, message: str, *args, **kwargs):
-        """Log debug message."""
-        self.logger.debug(message, *args, **kwargs)
-    
-    def info(self, message: str, *args, **kwargs):
-        """Log info message."""
-        self.logger.info(message, *args, **kwargs)
-    
-    def warning(self, message: str, *args, **kwargs):
-        """Log warning message."""
-        self.logger.warning(message, *args, **kwargs)
-    
-    def error(self, message: str, *args, **kwargs):
-        """Log error message."""
-        self.logger.error(message, *args, **kwargs)
-    
-    def critical(self, message: str, *args, **kwargs):
-        """Log critical message."""
-        self.logger.critical(message, *args, **kwargs)
-    
-    def setLevel(self, level):
-        """Set logger level."""
-        self.logger.setLevel(level)
+_DEFAULT_LOGGER_NAME = "zCLI"
+_CONFIGURED = False
 
 
-# Create default logger instance
-logger = zCLILogger("zCLI")
+def _configure_root_handler(stream: TextIO | None = None) -> logging.Handler:
+    handler = logging.StreamHandler(stream or sys.stdout)
+    handler.setFormatter(ColoredFormatter(datefmt="%H:%M:%S"))
+    return handler
 
 
-def get_logger(name: Optional[str] = None) -> zCLILogger:
-    """
-    Get a logger instance.
-    
-    Args:
-        name: Logger name (optional)
-        
-    Returns:
-        zCLILogger: Logger instance
-    """
-    if name:
-        return zCLILogger(name)
+def init_logging(
+    *,
+    level: int = logging.INFO,
+    stream: TextIO | None = None,
+    logger_name: str = _DEFAULT_LOGGER_NAME,
+) -> logging.Logger:
+    """Initialise the base logger used by the application."""
+
+    global _CONFIGURED, _DEFAULT_LOGGER_NAME
+
+    base_logger = logging.getLogger(logger_name)
+    if not _CONFIGURED:
+        handler = _configure_root_handler(stream)
+        base_logger.addHandler(handler)
+        base_logger.propagate = False
+        _CONFIGURED = True
+
+    base_logger.setLevel(level)
+    _DEFAULT_LOGGER_NAME = logger_name
+    return base_logger
+
+
+def get_logger(name: Optional[str] = None) -> logging.Logger:
+    """Return a logger, initialising the logging subsystem on first use."""
+
+    if not _CONFIGURED:
+        init_logging()
+
+    target_name = name or _DEFAULT_LOGGER_NAME
+    logger = logging.getLogger(target_name)
+    if target_name != _DEFAULT_LOGGER_NAME:
+        logger.setLevel(logging.NOTSET)
     return logger
 
 
-def set_log_level(level: str):
-    """
-    Set the log level for the default logger.
-    
-    Args:
-        level: Log level ('DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL')
-    """
+def set_log_level(level: str) -> None:
+    """Set the log level for the base logger."""
+
     level_map = {
-        'DEBUG': logging.DEBUG,
-        'INFO': logging.INFO,
-        'WARNING': logging.WARNING,
-        'ERROR': logging.ERROR,
-        'CRITICAL': logging.CRITICAL
+        "DEBUG": logging.DEBUG,
+        "INFO": logging.INFO,
+        "WARNING": logging.WARNING,
+        "ERROR": logging.ERROR,
+        "CRITICAL": logging.CRITICAL,
     }
-    
-    if level.upper() in level_map:
-        logger.logger.setLevel(level_map[level.upper()])
+
+    selected = level_map.get(level.upper())
+    base_logger = get_logger(_DEFAULT_LOGGER_NAME)
+    if selected is not None:
+        base_logger.setLevel(selected)
     else:
-        logger.warning(f"Invalid log level: {level}. Using INFO.")
-        logger.logger.setLevel(logging.INFO)
+        base_logger.warning("Invalid log level: %s. Using INFO.", level)
+        base_logger.setLevel(logging.INFO)

--- a/zCLI/zCore/main.py
+++ b/zCLI/zCore/main.py
@@ -8,34 +8,41 @@ import argparse
 # Add project root to path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
 
-from zCLI.zCore.zCLI import zCLI
-from zCLI.version import get_version, get_package_info
-from zCLI.utils.logger import logger
+from zCLI.version import get_version
+from zCLI.utils.logger import get_logger, init_logging
+
 
 def main():
     """Main entry point for zolo-zcli command."""
-    
+
+    init_logging()
+    main_logger = get_logger(__name__)
+
     # Set up argument parser
     parser = argparse.ArgumentParser(
         description='Zolo zCLI Framework - YAML-driven CLI for interactive applications',
         prog='zolo-zcli'
     )
-    parser.add_argument('--shell', action='store_true', 
+    parser.add_argument('--shell', action='store_true',
                        help='Start zCLI shell mode')
-    parser.add_argument('--version', action='version', 
+    parser.add_argument('--version', action='version',
                        version=f'zolo-zcli {get_version()}')
-    
+
     # Parse arguments
     args = parser.parse_args()
-    
+
     if args.shell:
         # Shell mode - start shell
-        logger.info("Starting zCLI Shell mode...")
-        cli = zCLI()
+        main_logger.info("Starting zCLI Shell mode...")
+        from zCLI.zCore.zCLI import zCLI
+
+        cli_logger = get_logger("zCLI")
+        cli = zCLI(logger=cli_logger)
         cli.run_shell()
     else:
         # Default: show help
         parser.print_help()
+
 
 if __name__ == "__main__":
     main()

--- a/zCLI/zCore/zCLI.py
+++ b/zCLI/zCore/zCLI.py
@@ -2,7 +2,10 @@
 # ───────────────────────────────────────────────────────────────
 """Core zCLI Engine - Single source of truth for all subsystems."""
 
-from zCLI.utils.logger import logger
+import logging
+from typing import Optional
+
+from zCLI.utils.logger import get_logger
 from zCLI.subsystems.zSession import create_session
 
 # Import all subsystems from the subsystems package
@@ -20,6 +23,9 @@ from zCLI.subsystems.zLoader import ZLoader
 from zCLI.subsystems.zExport import ZExport
 
 # Legacy ZCRUD wrapper (for backward compatibility)
+module_logger = get_logger(__name__)
+
+
 class ZCRUD:
     """Legacy ZCRUD wrapper - delegates to ZData."""
     def __init__(self, walker=None):
@@ -35,7 +41,7 @@ class ZCRUD:
         from zCLI.subsystems.zLoader import handle_zLoader
         
         # This is a simplified version - full logic is in zCRUD.py if needed
-        logger.warning("ZCRUD.handle() is deprecated - use ZData directly")
+        module_logger.warning("ZCRUD.handle() is deprecated - use ZData directly")
         return None
 
 
@@ -50,7 +56,7 @@ class zCLI:
     - Walker: Menu-driven interface using YAML files
     """
 
-    def __init__(self, zSpark_obj=None):
+    def __init__(self, zSpark_obj=None, logger: Optional[logging.Logger] = None):
         """
         Initialize a new zCLI instance.
 
@@ -84,7 +90,7 @@ class zCLI:
         self.zspark_obj = zSpark_obj or {}
 
         # Initialize logger
-        self.logger = logger
+        self.logger = logger or get_logger("zCLI")
 
         # Initialize zConfig FIRST (provides machine config)
         from zCLI.subsystems.zConfig import ZConfig
@@ -125,7 +131,7 @@ class zCLI:
         # Initialize session
         self._init_session()
 
-        logger.info("zCLI Core initialized - UI Mode: %s", self.ui_mode)
+        self.logger.info("zCLI Core initialized - UI Mode: %s", self.ui_mode)
 
     def _load_plugins(self):
         """Load utility plugins from zSpark_obj if provided."""
@@ -136,7 +142,7 @@ class zCLI:
             elif isinstance(plugin_paths, str):
                 self.utils.load_plugins([plugin_paths])
         except (ImportError, AttributeError, TypeError) as e:
-            logger.warning("Failed to load plugins: %s", e)
+            self.logger.warning("Failed to load plugins: %s", e)
 
     def _init_session(self):
         """
@@ -164,10 +170,10 @@ class zCLI:
             # Shell mode - always Terminal
             self.session["zMode"] = "Terminal"
 
-        logger.debug("Session initialized:")
-        logger.debug("  zS_id: %s", self.session["zS_id"])
-        logger.debug("  zMode: %s", self.session["zMode"])
-        logger.debug("  zMachine hostname: %s", self.session["zMachine"].get("hostname"))
+        self.logger.debug("Session initialized:")
+        self.logger.debug("  zS_id: %s", self.session["zS_id"])
+        self.logger.debug("  zMode: %s", self.session["zMode"])
+        self.logger.debug("  zMachine hostname: %s", self.session["zMachine"].get("hostname"))
 
     # ───────────────────────────────────────────────────────────────
     # Public API Methods
@@ -201,10 +207,10 @@ class zCLI:
             Result from walker or shell execution
         """
         if self.ui_mode:
-            logger.info("Starting zCLI in UI mode via zWalker...")
+            self.logger.info("Starting zCLI in UI mode via zWalker...")
             from zCLI.subsystems.zWalker.zWalker import zWalker  # pylint: disable=import-outside-toplevel
             walker = zWalker(self)  # Pass zCLI instance
             return walker.run()
 
-        logger.info("Starting zCLI in shell mode...")
+        self.logger.info("Starting zCLI in shell mode...")
         return self.run_shell()


### PR DESCRIPTION
## Summary
- replace the eager logger singleton with `init_logging`/`get_logger` helpers that lazily configure handlers when first used
- initialize logging in `zCLI/zCore/main.py`, pass the configured logger into `zCLI`, and let the core engine and subsystems rely on injected or module-specific loggers
- update subsystems to obtain loggers via `get_logger(__name__)` or parent instances so logging honors the configuration chosen at startup

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e4b6a9d884832bb520c75e0d5d01cd