### PR TITLE
Rename error handler utility to zTraceback

### DIFF
--- a/Demos/zcli-features/Interactive_Traceback/README.md
+++ b/Demos/zcli-features/Interactive_Traceback/README.md
@@ -90,7 +90,7 @@ try:
     result = 10 / 0
 except Exception as e:
     # Launch interactive traceback UI
-    zcli.error_handler.interactive_handler(
+    zcli.zTraceback.interactive_handler(
         e,
         operation=lambda: 10 / 0,  # Optional: for retry
         context={'user_id': 123}    # Optional: additional context

--- a/Demos/zcli-features/Interactive_Traceback/demo_interactive_traceback.py
+++ b/Demos/zcli-features/Interactive_Traceback/demo_interactive_traceback.py
@@ -49,7 +49,7 @@ def main():
         print("\n[LAUNCHING] Interactive Traceback UI...\n")
         
         # Launch the interactive traceback UI
-        result = zcli.error_handler.interactive_handler(
+        result = zcli.zTraceback.interactive_handler(
             e,
             operation=failing_operation,
             context={

--- a/Documentation/Release/RELEASE_1.5.2.md
+++ b/Documentation/Release/RELEASE_1.5.2.md
@@ -15,12 +15,12 @@ This release focuses on improving developer onboarding, test infrastructure, rep
 
 ## 🔧 Core Infrastructure
 
-### Centralized Error Handling
-- **Added**: `ErrorHandler` utility in `zCLI/utils/error_handler.py`
+### Centralized Traceback Handling
+- **Added**: `ZTraceback` utility in `zCLI/utils/zTraceback.py`
   - Enhanced traceback formatting with structured error information
   - Context-aware error logging for better debugging
   - `ExceptionContext` manager for cleaner exception handling
-  - Available system-wide via `zcli.error_handler`
+  - Available system-wide via `zcli.zTraceback`
 
 - **Centralized**: `traceback` module in `zCLI/__init__.py`
   - Single source of truth for traceback handling
@@ -38,14 +38,14 @@ This release focuses on improving developer onboarding, test infrastructure, rep
 self.logger.error("Error message", exc_info=True)
 
 # Enhanced with context (optional)
-self.zcli.error_handler.log_exception(
+self.zcli.zTraceback.log_exception(
     e, 
     message="Error during operation",
     context={'action': 'insert', 'table': 'users'}
 )
 
 # Context manager for cleaner code
-with ExceptionContext(self.zcli.error_handler, 
+with ExceptionContext(self.zcli.zTraceback, 
                       operation="database insert",
                       default_return="error"):
     result = perform_operation()
@@ -351,7 +351,7 @@ pip install git+https://github.com/ZoloAi/zolo-zcli.git
 ## 🔄 Changes Summary
 
 **Core Infrastructure**:
-- Centralized error handling with ErrorHandler utility
+- Centralized error handling with ZTraceback utility
 - Traceback module centralized in zCLI/__init__.py
 - Enhanced error logging with context support
 - ExceptionContext manager for cleaner exception handling

--- a/Documentation/Release/RELEASE_1.5.3.md
+++ b/Documentation/Release/RELEASE_1.5.3.md
@@ -45,7 +45,7 @@ Select option (1-4):
 
 ### **Core Components**
 
-#### **1. Enhanced ErrorHandler**
+#### **1. Enhanced ZTraceback**
 - **Exception Context Storage**: Stores last exception, operation, and context
 - **Exception History**: Maintains stack of exceptions for navigation
 - **Interactive Handler**: Launches Walker UI for exception handling
@@ -55,7 +55,7 @@ Select option (1-4):
 
 ```python
 # Launch interactive traceback UI
-zcli.error_handler.interactive_handler(
+zcli.zTraceback.interactive_handler(
     exception,
     operation=lambda: retry_function(),
     context={'user_id': 123, 'action': 'delete'}
@@ -95,9 +95,9 @@ Complete YAML definition in `zUI.zcli_sys.yaml`:
 ```yaml
 Traceback:
   ~Root*: ["^View Details", "^Retry Operation", "^Exception History", "stop"]
-  "^View Details": "zFunc(@.zCLI.utils.error_handler.display_formatted_traceback)"
-  "^Retry Operation": "zFunc(@.zCLI.utils.error_handler.retry_last_operation)"
-  "^Exception History": "zFunc(@.zCLI.utils.error_handler.show_exception_history)"
+  "^View Details": "zFunc(@.zCLI.utils.zTraceback.display_formatted_traceback)"
+  "^Retry Operation": "zFunc(@.zCLI.utils.zTraceback.retry_last_operation)"
+  "^Exception History": "zFunc(@.zCLI.utils.zTraceback.show_exception_history)"
 ```
 
 ---
@@ -308,10 +308,10 @@ Comprehensive materials included:
 
 ## 🔧 **Technical Implementation**
 
-### **ErrorHandler Enhancements**
+### **ZTraceback Enhancements**
 
 ```python
-class ErrorHandler:
+class ZTraceback:
     def __init__(self, logger=None, zcli=None):
         self.logger = logger
         self.zcli = zcli  # Reference to parent zCLI instance
@@ -346,7 +346,7 @@ class ErrorHandler:
 try:
     risky_operation()
 except Exception as e:
-    zcli.error_handler.interactive_handler(e)
+    zcli.zTraceback.interactive_handler(e)
 ```
 
 #### **With Retry Support**
@@ -354,7 +354,7 @@ except Exception as e:
 try:
     database_operation(user_id=123)
 except Exception as e:
-    zcli.error_handler.interactive_handler(
+    zcli.zTraceback.interactive_handler(
         e,
         operation=lambda: database_operation(user_id=123),
         context={'user_id': 123}
@@ -366,7 +366,7 @@ except Exception as e:
 try:
     process_data(data)
 except Exception as e:
-    zcli.error_handler.interactive_handler(
+    zcli.zTraceback.interactive_handler(
         e,
         operation=lambda: process_data(data),
         context={
@@ -406,13 +406,13 @@ except Exception as e:
 ## 📝 **Testing**
 
 ### **Test Suite**
-- **zErrorHandler_Test.py**: Comprehensive ErrorHandler unit tests (32 tests)
-- **zIntegration_Test.py**: ErrorHandler integration tests (5 tests)
+- **zTraceback_Test.py**: Comprehensive ZTraceback unit tests (32 tests)
+- **zIntegration_Test.py**: ZTraceback integration tests (5 tests)
 - **zEndToEnd_Test.py**: Error handling workflow tests (3 tests)
 
 ### **Test Coverage**
 ```
-✓ ErrorHandler initialization and configuration
+✓ ZTraceback initialization and configuration
 ✓ Exception formatting (basic and with locals)
 ✓ Traceback info extraction and structured data
 ✓ Exception logging with context
@@ -435,7 +435,7 @@ Total: 40 tests, all passing ✅
 ### **1. Interactive Traceback System**
 
 **Core Infrastructure**:
-- Enhanced ErrorHandler with interactive support
+- Enhanced ZTraceback with interactive support
 - Added exception context storage (last_exception, last_operation, last_context)
 - Implemented interactive_handler() method
 - Added exception history tracking
@@ -451,7 +451,7 @@ Total: 40 tests, all passing ✅
 - zFunc-based menu actions
 
 **Testing**:
-- zErrorHandler_Test.py - comprehensive unit tests (32 tests, 6 test classes)
+- zTraceback_Test.py - comprehensive unit tests (32 tests, 6 test classes)
 - Integration tests in zIntegration_Test.py (5 integration tests)
 - End-to-end tests in zEndToEnd_Test.py (3 workflow tests)
 - Total: 40 tests, all passing ✅
@@ -544,12 +544,12 @@ Total: 40 tests, all passing ✅
 **Test Suite Cleanup**:
 - **Removed duplicate test file**: `zDisplay_New_Test.py` (draft version, 408 lines)
 - **Kept production version**: `zDisplay_Test.py` (comprehensive, 674 lines, properly integrated)
-- **Added new comprehensive test**: `zErrorHandler_Test.py` (32 tests across 6 test classes)
-- **Updated test integration**: Added ErrorHandler tests to Integration and EndToEnd suites
+- **Added new comprehensive test**: `zTraceback_Test.py` (32 tests across 6 test classes)
+- **Updated test integration**: Added ZTraceback tests to Integration and EndToEnd suites
 
 **Final Test Count**: 20 test modules, all properly integrated
-1. Unit tests: zConfig, zComm, zBifrost, zDisplay, zAuth, zDispatch, zNavigation, zParser, zLoader, zFunc, zDialog, zOpen, zShell, zWizard, zUtils, **zErrorHandler**, zData, zWalker
-2. Integration tests: 9 test classes (including ErrorHandler integration)
+1. Unit tests: zConfig, zComm, zBifrost, zDisplay, zAuth, zDispatch, zNavigation, zParser, zLoader, zFunc, zDialog, zOpen, zShell, zWizard, zUtils, **zZTraceback**, zData, zWalker
+2. Integration tests: 9 test classes (including ZTraceback integration)
 3. End-to-end tests: 7 test classes (including error handling workflows)
 
 **Benefits**:
@@ -559,7 +559,7 @@ Total: 40 tests, all passing ✅
 - **Consistent Formatting**: Standardized `[STATUS]` indicators throughout
 - **No Duplicates**: Removed redundant test files, cleaner repo
 
-**Verification**: All tests pass after cleanup ✅ (32 ErrorHandler + 16 Integration + 12 EndToEnd = 60 tests for ErrorHandler coverage)
+**Verification**: All tests pass after cleanup ✅ (32 ZTraceback + 16 Integration + 12 EndToEnd = 60 tests for ZTraceback coverage)
 
 ### **6. Version Update**
 

--- a/zCLI/UI/zUI.zcli_sys.yaml
+++ b/zCLI/UI/zUI.zcli_sys.yaml
@@ -6,6 +6,6 @@ Uninstall:
 
 Traceback:
   ~Root*: ["^View Details", "Retry Operation", "Exception History", "stop"]
-  "^View Details": "zFunc(@.utils.error_handler.display_formatted_traceback)"
-  "Retry Operation": "zFunc(@.utils.error_handler.retry_last_operation)"
-  "^Exception History": "zFunc(@.utils.error_handler.show_exception_history)"
+  "^View Details": "zFunc(@.utils.zTraceback.display_formatted_traceback)"
+  "Retry Operation": "zFunc(@.utils.zTraceback.retry_last_operation)"
+  "^Exception History": "zFunc(@.utils.zTraceback.show_exception_history)"

--- a/zCLI/utils/__init__.py
+++ b/zCLI/utils/__init__.py
@@ -7,13 +7,13 @@ Provides common utilities and plugins for zCLI subsystems.
 """
 
 from .colors import Colors, print_ready_message
-from .error_handler import ErrorHandler, ExceptionContext
+from .zTraceback import ZTraceback, ExceptionContext
 from .validation import validate_zcli_instance
 
 __all__ = [
     "Colors",
     "print_ready_message",
-    "ErrorHandler",
+    "ZTraceback",
     "ExceptionContext",
     "validate_zcli_instance",
 ]

--- a/zCLI/zCLI.py
+++ b/zCLI/zCLI.py
@@ -39,9 +39,9 @@ class zCLI:
         # Log initial message with configured level
         self.logger.info("Logger initialized at level: %s", session_logger.log_level) # First log message
 
-        # Initialize centralized error handler
-        from .utils.error_handler import ErrorHandler
-        self.error_handler = ErrorHandler(logger=self.logger, zcli=self)
+        # Initialize centralized traceback utility
+        from .utils.zTraceback import ZTraceback
+        self.zTraceback = ZTraceback(logger=self.logger, zcli=self)
 
         # Initialize zComm (Communication infrastructure for zBifrost and zData)
         from .subsystems.zComm import zComm

--- a/zTestSuite/run_all_tests.py
+++ b/zTestSuite/run_all_tests.py
@@ -37,7 +37,7 @@ TEST_MODULES = [
     'zShell',
     'zWizard',
     'zUtils',
-    'zErrorHandler',  # Error handling and interactive traceback (v1.5.3)
+    'zTraceback',  # Traceback handling and interactive error UI (v1.5.3)
     'zData',
     'zWalker',
     'zIntegration',  # Integration tests - test multiple subsystems working together

--- a/zTestSuite/zIntegration_Test.py
+++ b/zTestSuite/zIntegration_Test.py
@@ -33,7 +33,7 @@ class TestzCLIInitialization(unittest.TestCase):
             self.assertIsNotNone(z.config)
             self.assertIsNotNone(z.logger)
             self.assertIsNotNone(z.display)
-            self.assertIsNotNone(z.error_handler)
+            self.assertIsNotNone(z.zTraceback)
             self.assertIsNotNone(z.loader)
             self.assertIsNotNone(z.zparser)
             self.assertIsNotNone(z.dispatch)
@@ -479,80 +479,80 @@ class TestWebSocketModeIntegration(unittest.TestCase):
         self.assertIsNotNone(result)
 
 
-class TestErrorHandlerIntegration(unittest.TestCase):
-    """Test ErrorHandler integration with other subsystems."""
-    
-    def test_error_handler_with_logger(self):
-        """Test ErrorHandler is properly initialized with logger."""
+class TestZTracebackIntegration(unittest.TestCase):
+    """Test ZTraceback integration with other subsystems."""
+
+    def test_ztraceback_with_logger(self):
+        """Test ZTraceback is properly initialized with logger."""
         with tempfile.TemporaryDirectory() as tmpdir:
             z = zCLI({"zWorkspace": tmpdir})
-            
-            # ErrorHandler should have logger reference
-            self.assertIsNotNone(z.error_handler.logger)
-            self.assertIs(z.error_handler.logger, z.logger)
-    
-    def test_error_handler_with_zcli_reference(self):
-        """Test ErrorHandler has reference to zCLI instance."""
+
+            # ZTraceback should have logger reference
+            self.assertIsNotNone(z.zTraceback.logger)
+            self.assertIs(z.zTraceback.logger, z.logger)
+
+    def test_ztraceback_with_zcli_reference(self):
+        """Test ZTraceback has reference to zCLI instance."""
         with tempfile.TemporaryDirectory() as tmpdir:
             z = zCLI({"zWorkspace": tmpdir})
-            
-            # ErrorHandler should have zcli reference for interactive features
-            self.assertIsNotNone(z.error_handler.zcli)
-            self.assertIs(z.error_handler.zcli, z)
-    
-    def test_error_handler_logs_to_zcli_logger(self):
-        """Test ErrorHandler logs exceptions to zCLI logger."""
+
+            # ZTraceback should have zcli reference for interactive features
+            self.assertIsNotNone(z.zTraceback.zcli)
+            self.assertIs(z.zTraceback.zcli, z)
+
+    def test_ztraceback_logs_to_zcli_logger(self):
+        """Test ZTraceback logs exceptions to zCLI logger."""
         with tempfile.TemporaryDirectory() as tmpdir:
             z = zCLI({"zWorkspace": tmpdir})
-            
+
             try:
                 raise ValueError("Integration test error")
             except ValueError as e:
                 # Should log without crashing
-                z.error_handler.log_exception(e, message="Test error logging")
-                
+                z.zTraceback.log_exception(e, message="Test error logging")
+
                 # Verify exception was stored for potential interactive handling
-                self.assertIsNotNone(z.error_handler.last_exception)
-    
-    def test_error_handler_with_display(self):
-        """Test ErrorHandler can use display for output."""
+                self.assertIsNotNone(z.zTraceback.last_exception)
+
+    def test_ztraceback_with_display(self):
+        """Test ZTraceback can use display for output."""
         with tempfile.TemporaryDirectory() as tmpdir:
             z = zCLI({"zWorkspace": tmpdir})
-            
+
             try:
                 raise RuntimeError("Display test error")
             except RuntimeError as e:
-                z.error_handler.last_exception = e
-                z.error_handler.last_context = {'test': 'value'}
-                
+                z.zTraceback.last_exception = e
+                z.zTraceback.last_context = {'test': 'value'}
+
                 # Should be able to format and display (though in tests it just runs)
-                from zCLI.utils.error_handler import display_formatted_traceback
+                from zCLI.utils.zTraceback import display_formatted_traceback
                 from unittest.mock import patch
-                
+
                 with patch.object(z.display, 'zDeclare'):
                     with patch.object(z.display, 'error'):
                         with patch.object(z.display, 'text'):
                             display_formatted_traceback(z)
-    
+
     def test_exception_context_with_zcli(self):
         """Test ExceptionContext works with zCLI instance."""
-        from zCLI.utils.error_handler import ExceptionContext
-        
+        from zCLI.utils.zTraceback import ExceptionContext
+
         with tempfile.TemporaryDirectory() as tmpdir:
             z = zCLI({"zWorkspace": tmpdir})
-            
-            # Use ExceptionContext with zCLI's error_handler
+
+            # Use ExceptionContext with zCLI's traceback handler
             with ExceptionContext(
-                z.error_handler,
+                z.zTraceback,
                 operation="test_operation",
                 context={'workspace': tmpdir},
                 reraise=False
             ):
                 # Simulate an error
                 pass  # No error - should not log anything
-            
-            # Verify error_handler is ready for next exception
-            self.assertIsNotNone(z.error_handler)
+
+            # Verify traceback handler is ready for next exception
+            self.assertIsNotNone(z.zTraceback)
 
 
 def run_tests(verbose=False):
@@ -569,7 +569,7 @@ def run_tests(verbose=False):
     suite.addTests(loader.loadTestsFromTestCase(TestEndToEndCRUDWorkflow))
     suite.addTests(loader.loadTestsFromTestCase(TestMultiSubsystemWorkflow))
     suite.addTests(loader.loadTestsFromTestCase(TestWebSocketModeIntegration))  # NEW v1.5.3
-    suite.addTests(loader.loadTestsFromTestCase(TestErrorHandlerIntegration))  # NEW v1.5.3
+    suite.addTests(loader.loadTestsFromTestCase(TestZTracebackIntegration))  # NEW v1.5.3
     
     runner = unittest.TextTestRunner(verbosity=2 if verbose else 1)
     result = runner.run(suite)

--- a/zTestSuite/zTraceback_Test.py
+++ b/zTestSuite/zTraceback_Test.py
@@ -1,52 +1,52 @@
 #!/usr/bin/env python3
-# zTestSuite/zErrorHandler_Test.py
+# zTestSuite/zTraceback_Test.py
 
 """
-Comprehensive test suite for ErrorHandler and interactive traceback.
+Comprehensive test suite for ZTraceback and interactive traceback.
 Tests exception handling, context management, and interactive UI features.
 """
 
 import unittest
 import sys
 from pathlib import Path
-from unittest.mock import Mock, MagicMock, patch
+from unittest.mock import Mock, patch
 from io import StringIO
 
 # Add parent directory to path to import zCLI
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from zCLI.utils.error_handler import ErrorHandler, ExceptionContext
-from zCLI.utils.error_handler import (
+from zCLI.utils.zTraceback import ZTraceback, ExceptionContext
+from zCLI.utils.zTraceback import (
     display_formatted_traceback,
     retry_last_operation,
     show_exception_history
 )
 
 
-class TestErrorHandlerInitialization(unittest.TestCase):
-    """Test ErrorHandler initialization."""
+class TestZTracebackInitialization(unittest.TestCase):
+    """Test ZTraceback initialization."""
 
     def test_initialization_without_logger(self):
-        """Test ErrorHandler initializes without logger."""
-        handler = ErrorHandler()
+        """Test ZTraceback initializes without logger."""
+        handler = ZTraceback()
         self.assertIsNone(handler.logger)
         self.assertIsNone(handler.zcli)
 
     def test_initialization_with_logger(self):
-        """Test ErrorHandler initializes with logger."""
+        """Test ZTraceback initializes with logger."""
         mock_logger = Mock()
-        handler = ErrorHandler(logger=mock_logger)
+        handler = ZTraceback(logger=mock_logger)
         self.assertEqual(handler.logger, mock_logger)
 
     def test_initialization_with_zcli(self):
-        """Test ErrorHandler initializes with zCLI instance."""
+        """Test ZTraceback initializes with zCLI instance."""
         mock_zcli = Mock()
-        handler = ErrorHandler(logger=None, zcli=mock_zcli)
+        handler = ZTraceback(logger=None, zcli=mock_zcli)
         self.assertEqual(handler.zcli, mock_zcli)
 
     def test_exception_context_storage_initialized(self):
         """Test exception context storage is initialized."""
-        handler = ErrorHandler()
+        handler = ZTraceback()
         self.assertIsNone(handler.last_exception)
         self.assertIsNone(handler.last_operation)
         self.assertEqual(handler.last_context, {})
@@ -58,7 +58,7 @@ class TestExceptionFormatting(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
-        self.handler = ErrorHandler()
+        self.handler = ZTraceback()
 
     def test_format_exception_basic(self):
         """Test basic exception formatting."""
@@ -111,7 +111,7 @@ class TestExceptionLogging(unittest.TestCase):
     def setUp(self):
         """Set up test fixtures."""
         self.mock_logger = Mock()
-        self.handler = ErrorHandler(logger=self.mock_logger)
+        self.handler = ZTraceback(logger=self.mock_logger)
 
     def test_log_exception_basic(self):
         """Test basic exception logging."""
@@ -154,7 +154,7 @@ class TestExceptionLogging(unittest.TestCase):
 
     def test_log_exception_without_logger_prints_to_stderr(self):
         """Test log_exception falls back to stderr when no logger."""
-        handler = ErrorHandler()  # No logger
+        handler = ZTraceback()  # No logger
         
         with patch('sys.stderr', new_callable=StringIO) as mock_stderr:
             try:
@@ -173,7 +173,7 @@ class TestExceptionContext(unittest.TestCase):
     def setUp(self):
         """Set up test fixtures."""
         self.mock_logger = Mock()
-        self.handler = ErrorHandler(logger=self.mock_logger)
+        self.handler = ZTraceback(logger=self.mock_logger)
 
     def test_context_manager_no_exception(self):
         """Test ExceptionContext when no exception occurs."""
@@ -248,9 +248,9 @@ class TestInteractiveTraceback(unittest.TestCase):
         self.mock_zcli.session = {"zMode": "Terminal"}
         self.mock_zcli.logger = Mock()
         self.mock_zcli.display = Mock()
-        self.handler = ErrorHandler(logger=self.mock_zcli.logger, zcli=self.mock_zcli)
-        # Important: Set up the mock so zcli.error_handler points to our handler
-        self.mock_zcli.error_handler = self.handler
+        self.handler = ZTraceback(logger=self.mock_zcli.logger, zcli=self.mock_zcli)
+        # Important: Set up the mock so zcli.zTraceback points to our handler
+        self.mock_zcli.zTraceback = self.handler
 
     def test_exception_history_storage(self):
         """Test exception history is stored correctly."""
@@ -385,7 +385,7 @@ class TestInteractiveTraceback(unittest.TestCase):
         """Test interactive_handler attempts to launch UI."""
         # This test is complex due to dynamic imports and zCLI instantiation
         # We'll test that it handles missing zcli gracefully
-        handler_no_zcli = ErrorHandler()
+        handler_no_zcli = ZTraceback()
         
         try:
             raise ValueError("Interactive test")
@@ -401,7 +401,7 @@ class TestInteractiveTraceback(unittest.TestCase):
 
     def test_interactive_handler_without_zcli(self):
         """Test interactive_handler falls back gracefully without zCLI."""
-        handler = ErrorHandler()  # No zcli
+        handler = ZTraceback()  # No zcli
         
         with patch('sys.stderr', new_callable=StringIO) as mock_stderr:
             try:
@@ -419,7 +419,7 @@ class TestEdgeCases(unittest.TestCase):
 
     def test_handler_with_none_exception(self):
         """Test handler methods with None exception."""
-        handler = ErrorHandler()
+        handler = ZTraceback()
         
         # Should not crash
         try:
@@ -430,7 +430,7 @@ class TestEdgeCases(unittest.TestCase):
 
     def test_get_traceback_info_with_complex_exception(self):
         """Test get_traceback_info with nested exception."""
-        handler = ErrorHandler()
+        handler = ZTraceback()
         
         def inner_function():
             raise ValueError("Inner error")
@@ -449,7 +449,7 @@ class TestEdgeCases(unittest.TestCase):
 
     def test_exception_with_unicode_message(self):
         """Test exception handling with unicode characters."""
-        handler = ErrorHandler()
+        handler = ZTraceback()
         
         try:
             raise ValueError("Unicode error: 世界 🌍")
@@ -460,7 +460,7 @@ class TestEdgeCases(unittest.TestCase):
 
     def test_very_deep_traceback(self):
         """Test handling of very deep call stacks."""
-        handler = ErrorHandler()
+        handler = ZTraceback()
         
         def recursive_function(depth):
             if depth == 0:
@@ -475,12 +475,12 @@ class TestEdgeCases(unittest.TestCase):
 
 
 def run_tests(verbose=False):
-    """Run all ErrorHandler tests with proper test discovery."""
+    """Run all ZTraceback tests with proper test discovery."""
     loader = unittest.TestLoader()
     suite = unittest.TestSuite()
 
     # Add all test classes
-    suite.addTests(loader.loadTestsFromTestCase(TestErrorHandlerInitialization))
+    suite.addTests(loader.loadTestsFromTestCase(TestZTracebackInitialization))
     suite.addTests(loader.loadTestsFromTestCase(TestExceptionFormatting))
     suite.addTests(loader.loadTestsFromTestCase(TestExceptionLogging))
     suite.addTests(loader.loadTestsFromTestCase(TestExceptionContext))


### PR DESCRIPTION
## Summary
- rename the error handler module to zTraceback and update the zCLI core to expose `zTraceback`
- refresh demos, release documentation, and UI definitions to point at the new traceback utility
- update and rename all traceback-related tests to target the ZTraceback module

## Testing
- pytest zTestSuite/zTraceback_Test.py
- pytest zTestSuite/zIntegration_Test.py::TestZTracebackIntegration --maxfail=1
- pytest zTestSuite/zEndToEnd_Test.py::TestTracebackWorkflow --maxfail=1

------
https://chatgpt.com/codex/tasks/task_b_68fcd181efec832bbaebfb1867cdc50e