### PR TITLE
Refine logger formatting for console and file output

### DIFF
--- a/zCLI/zCLI.py
+++ b/zCLI/zCLI.py
@@ -28,13 +28,8 @@ class zCLI:
         # Get logger from session (initialized during session creation)
         session_logger = self.session["logger_instance"]
 
-        # Create zCLI-specific logger that will show "zCLI" in logs
-        self.logger = logging.getLogger("zCLI")
-        self.logger.setLevel(session_logger._logger.level)  # Use same level as session logger
-
-        # Add the same handlers as the session logger so messages get processed
-        for handler in session_logger._logger.handlers:
-            self.logger.addHandler(handler)
+        # Use the session-configured logger instance directly
+        self.logger = session_logger._logger
 
         # Log initial message with configured level
         self.logger.info("Logger initialized at level: %s", session_logger.log_level) # First log message


### PR DESCRIPTION
## Summary
- show subsystem module names in logger output for better granularity
- use separate console and file formatters to provide clean console logs and detailed file logs
- reuse the session-configured logger instance directly in the core engine

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68fceb86cb14832bac3c3b7bc930a1ec