### PR TITLE
Refine logger formatting

### DIFF
--- a/zCLI/subsystems/zConfig/zConfig.py
+++ b/zCLI/subsystems/zConfig/zConfig.py
@@ -1,7 +1,6 @@
 # zCLI/subsystems/zConfig/zConfig.py
 """Cross-platform configuration management with hierarchical loading and secret support."""
 
-from zCLI import logging
 from zCLI.utils import print_ready_message, validate_zcli_instance
 from .zConfig_modules import (
     zConfigPaths,
@@ -44,13 +43,8 @@ class zConfig:
         # Get logger from session (initialized during session creation)
         session_logger = session_data["logger_instance"]
 
-        # Create zCLI-specific logger that will show "zCLI" in logs
-        zcli.logger = logging.getLogger("zCLI")
-        zcli.logger.setLevel(session_logger._logger.level)  # Use same level as session logger
-
-        # Add the same handlers as the session logger so messages get processed
-        for handler in session_logger._logger.handlers:
-            zcli.logger.addHandler(handler)
+        # Use the logger instance created during session initialization
+        zcli.logger = session_logger._logger
 
         # Log initial message with configured level
         zcli.logger.info("Logger initialized at level: %s", session_logger.log_level)

--- a/zCLI/subsystems/zConfig/zConfig_modules/config_logger.py
+++ b/zCLI/subsystems/zConfig/zConfig_modules/config_logger.py
@@ -74,14 +74,28 @@ class LoggerConfig:
         """Extract caller file information from log record."""
         pathname = record.pathname
         
-        # For zCLI subsystems, show the subsystem name instead of the full file path
+        # For zCLI subsystems, show hierarchical subsystem/module names
         if 'zCLI/subsystems/' in pathname:
             # Extract subsystem name from path like: /path/to/zCLI/subsystems/zComm/zComm.py
             parts = pathname.split('zCLI/subsystems/')
             if len(parts) > 1:
                 subsystem_part = parts[1]
                 # Get the first directory after subsystems (e.g., zComm from zComm/zComm.py)
-                subsystem = subsystem_part.split('/')[0]
+                subsystem_segments = subsystem_part.split('/')
+                subsystem = subsystem_segments[0]
+
+                # Determine module filename (if available)
+                if len(subsystem_segments) > 1:
+                    module_filename = subsystem_segments[-1]
+                    module, _ = os.path.splitext(module_filename)
+
+                    # If the module filename matches the subsystem, return subsystem only
+                    if module == subsystem:
+                        return subsystem
+
+                    # Otherwise return hierarchical name subsystem.module
+                    return f"{subsystem}.{module}"
+
                 return subsystem
         
         # For zCLI core files, show the module name
@@ -135,29 +149,41 @@ class LoggerConfig:
         
         # Setup formatters based on format setting
         if log_format == "json":
-            formatter = FileNameFormatter(
+            console_formatter = FileNameFormatter(
                 self,
-                '{"time":"%(asctime)s","level":"%(levelname)s","name":"%(name)s",'
-                '"message":"%(message)s"}'
+                '{"level":"%(levelname)s","name":"%(name)s","message":"%(message)s"}'
+            )
+            file_formatter = FileNameFormatter(
+                self,
+                '{"time":"%(asctime)s","level":"%(levelname)s","name":"%(name)s","file":"%(filename)s","line":%(lineno)d,"message":"%(message)s"}'
             )
         elif log_format == "simple":
-            formatter = FileNameFormatter(
+            console_formatter = FileNameFormatter(
                 self,
                 '%(levelname)s: %(message)s'
             )
-        else:  # detailed
-            formatter = FileNameFormatter(
+            file_formatter = FileNameFormatter(
                 self,
-                '%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+                '%(asctime)s - %(levelname)s: %(message)s',
                 datefmt='%Y-%m-%d %H:%M:%S'
             )
-        
+        else:  # detailed
+            console_formatter = FileNameFormatter(
+                self,
+                '%(name)s - %(levelname)s - %(message)s'
+            )
+            file_formatter = FileNameFormatter(
+                self,
+                '%(asctime)s - %(name)s - %(levelname)s - [%(filename)s:%(lineno)d] - %(message)s',
+                datefmt='%Y-%m-%d %H:%M:%S'
+            )
+
         # Console handler (always enabled)
         console_handler = logging.StreamHandler()
         console_handler.setLevel(getattr(logging, self.log_level))
-        console_handler.setFormatter(formatter)
+        console_handler.setFormatter(console_formatter)
         self._logger.addHandler(console_handler)
-        
+
         # File handler (if enabled)
         if file_enabled:
             try:
@@ -166,11 +192,11 @@ class LoggerConfig:
                 log_file = Path(file_path)
                 
                 log_file.parent.mkdir(parents=True, exist_ok=True)
-                
+
                 # Create file handler
                 file_handler = logging.FileHandler(str(log_file))
                 file_handler.setLevel(getattr(logging, self.log_level))
-                file_handler.setFormatter(formatter)
+                file_handler.setFormatter(file_formatter)
                 self._logger.addHandler(file_handler)
                 
                 print(f"[LoggerConfig] File logging enabled: {file_path}")


### PR DESCRIPTION
## Summary
- enhance subsystem caller detection to report hierarchical module names
- separate console and file logging formats for cleaner terminal output and richer log files
- reuse the session logger instance directly when wiring zCLI logging

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68fcec73fc04832b849438bb9481acf9