### PR TITLE
Refactor zBifrost to event-driven events architecture

### DIFF
--- a/zCLI/subsystems/zComm/README_REFACTORING.md
+++ b/zCLI/subsystems/zComm/README_REFACTORING.md
@@ -60,6 +60,18 @@ zComm/
 **Key Methods:**
 - `check_port(port)` - Check if port is available
 
+### 4. `zBifrost.bridge_modules.events` - Event Packages (NEW)
+**Responsibilities:**
+- Domain-specific routers for the WebSocket bridge (`client`, `cache`, `discovery`, `dispatch`)
+- Share logic with zDisplay by standardizing on the `event` field
+- Provide a single entry point for future event additions
+
+**Highlights:**
+- `bifrost_bridge_modular.py` now constructs an `_event_map` that routes every
+  message through `handle_message`, mirroring zDisplay's architecture.
+- Backward compatibility helpers translate legacy `action` payloads to events.
+- Documentation is consolidated in `MESSAGE_PROTOCOL.md` and `MIGRATION_GUIDE.md`.
+
 ## Benefits
 
 ### 1. **Separation of Concerns**

--- a/zCLI/subsystems/zComm/zComm_modules/zBifrost/HOOKS_GUIDE.md
+++ b/zCLI/subsystems/zComm/zComm_modules/zBifrost/HOOKS_GUIDE.md
@@ -4,6 +4,10 @@
 
 BifrostClient provides a **primitive hooks system** that allows you to customize behavior without modifying the core library. Hooks are callbacks that fire at specific points in the WebSocket lifecycle.
 
+> **Protocol note:** All incoming/outgoing messages include an `event` field.
+> Review [`MESSAGE_PROTOCOL.md`](MESSAGE_PROTOCOL.md) for canonical payloads
+> when building custom hooks that emit messages back to the server.
+
 ## Hook Philosophy
 
 **Primitive & Composable**: Hooks are intentionally simple building blocks. You can compose complex behavior by combining multiple hooks.
@@ -72,12 +76,12 @@ Called for **every** message received (before any processing).
 onMessage: (msg) => {
   // Log all messages
   console.log('📨 Message:', msg);
-  
+
   // Track metrics
   messageCounter++;
-  
+
   // Custom routing
-  if (msg.type === 'analytics') {
+  if (msg.event === 'analytics') {
     sendToAnalytics(msg.data);
   }
 }
@@ -89,11 +93,11 @@ Called for server-initiated broadcast messages (not responses to requests).
 ```javascript
 onBroadcast: (msg) => {
   // Handle real-time updates
-  if (msg.type === 'user_joined') {
+  if (msg.event === 'user_joined') {
     updateUserList(msg.user);
   }
-  
-  if (msg.type === 'notification') {
+
+  if (msg.event === 'notification') {
     showNotification(msg.text);
   }
 }
@@ -190,7 +194,7 @@ const client = new BifrostClient('ws://localhost:8765', {
     onMessage: (msg) => {
       // Log to analytics
       analytics.track('bifrost_message', {
-        type: msg.type,
+        event: msg.event,
         timestamp: Date.now()
       });
     },
@@ -209,7 +213,7 @@ const client = new BifrostClient('ws://localhost:8765', {
   hooks: {
     onBroadcast: (msg) => {
       // Handle real-time updates
-      switch (msg.type) {
+      switch (msg.event) {
         case 'user_typing':
           showTypingIndicator(msg.user);
           break;
@@ -364,7 +368,7 @@ const client = new BifrostClient('ws://localhost:8765', {
     
     // Handle broadcasts (real-time updates)
     onBroadcast: (msg) => {
-      if (msg.type === 'data_updated') {
+      if (msg.event === 'data_updated') {
         // Refresh your UI
         refreshDataTable();
       }

--- a/zCLI/subsystems/zComm/zComm_modules/zBifrost/MESSAGE_PROTOCOL.md
+++ b/zCLI/subsystems/zComm/zComm_modules/zBifrost/MESSAGE_PROTOCOL.md
@@ -1,0 +1,111 @@
+# zBifrost Message Protocol
+
+zBifrost now follows the same event-driven contract as `zDisplay`. Every
+message **must** include an `event` field that identifies which handler will
+process the payload. This file documents the canonical events supported by the
+bridge and the expected payload shape for each domain package.
+
+## Envelope
+
+```json
+{
+  "event": "<event-name>",
+  "_requestId": 42,        // Optional: request/response correlation
+  "data": { ... }          // Optional: structured payload for specific events
+}
+```
+
+> **Backward compatibility** – Messages that still use the legacy `action`
+> field are automatically translated to their corresponding `event` value when
+> possible. New integrations should always set `event` explicitly.
+
+## Client Events (`bridge_modules/events/client_events.py`)
+
+| Event            | Description                                       | Payload Fields                               |
+|------------------|---------------------------------------------------|-----------------------------------------------|
+| `connection_info`| Request a fresh snapshot of server state.         | Optional `context` hint. Response includes `auth`, `cache_stats`, and session metadata. |
+| `input_response` | Respond to a pending zDisplay input request.      | `requestId` (string), `value` (any).          |
+
+### Examples
+
+```json
+{
+  "event": "connection_info"
+}
+```
+
+```json
+{
+  "event": "input_response",
+  "requestId": "login.email",
+  "value": "user@example.com"
+}
+```
+
+## Cache Events (`bridge_modules/events/cache_events.py`)
+
+| Event           | Description                                   | Payload Fields                               |
+|-----------------|-----------------------------------------------|-----------------------------------------------|
+| `get_schema`    | Retrieve schema definition for a model.       | `model` (string)                              |
+| `clear_cache`   | Clear schema + query caches.                   | *(none)*                                      |
+| `cache_stats`   | Inspect cache statistics.                      | *(none)*                                      |
+| `set_cache_ttl` | Update default TTL (seconds) for query cache.  | `ttl` (int, defaults to `60`)                 |
+
+### Example
+
+```json
+{
+  "event": "set_cache_ttl",
+  "ttl": 120
+}
+```
+
+## Discovery Events (`bridge_modules/events/discovery_events.py`)
+
+| Event        | Description                               | Payload Fields                |
+|--------------|-------------------------------------------|-------------------------------|
+| `discover`   | Enumerate discoverable models/resources.  | *(none)*                      |
+| `introspect` | Inspect a specific model's schema.        | `model` (string)              |
+
+### Example
+
+```json
+{
+  "event": "introspect",
+  "model": "@.zCloud.schemas.schema.zIndex.zUsers"
+}
+```
+
+## Dispatch Events (`bridge_modules/events/dispatch_events.py`)
+
+All command routing is consolidated under the `dispatch` event. The payload is
+forwarded to zDispatch unchanged. Use the traditional `action`, `model`, `zKey`,
+and `filters` keys as needed.
+
+| Event      | Description                                        | Payload Fields                                |
+|------------|----------------------------------------------------|-----------------------------------------------|
+| `dispatch` | Execute a zDispatch command or declarative request.| `zKey` / `cmd`, optional `action`, `model`, etc. |
+
+### Example
+
+```json
+{
+  "event": "dispatch",
+  "zKey": "^List.users",
+  "action": "read",
+  "filters": {"active": true}
+}
+```
+
+## Error Handling
+
+* Unknown events are logged and rebroadcast to connected clients for
+  transparency.
+* Non-JSON payloads are rebroadcast verbatim.
+* Handlers may emit `{"error": "<message>"}` responses when an operation fails.
+
+## Related Documents
+
+* [`README.md`](README.md) – Architectural overview.
+* [`MIGRATION_GUIDE.md`](MIGRATION_GUIDE.md) – Step-by-step guidance for
+  upgrading from legacy `action` messages.

--- a/zCLI/subsystems/zComm/zComm_modules/zBifrost/MIGRATION_GUIDE.md
+++ b/zCLI/subsystems/zComm/zComm_modules/zBifrost/MIGRATION_GUIDE.md
@@ -1,0 +1,63 @@
+# zBifrost Event Migration Guide
+
+The v2 refactor standardizes all WebSocket traffic on the `event` field. This
+guide explains how to migrate existing integrations that relied on the legacy
+`action` contract.
+
+## 1. Update Client Payloads
+
+| Legacy Payload                              | New Payload (event-based)                         |
+|---------------------------------------------|---------------------------------------------------|
+| `{ "action": "get_schema", "model": "User" }` | `{ "event": "get_schema", "model": "User" }` |
+| `{ "action": "clear_cache" }`               | `{ "event": "clear_cache" }`                   |
+| `{ "zKey": "^List.users" }`                 | `{ "event": "dispatch", "zKey": "^List.users" }` |
+| `{ "cmd": "^List.users" }`                  | `{ "event": "dispatch", "cmd": "^List.users" }` |
+| `{ "action": "read", "model": "User" }`   | `{ "event": "dispatch", "action": "read", "model": "User" }` |
+
+> **Tip:** You can keep the `action` field when it conveys semantics for
+> zDispatch. zBifrost will forward both `event` and `action` to the dispatcher.
+
+## 2. Normalize Custom Hooks
+
+If you emit custom messages from hooks or extensions, add the `event` key:
+
+```javascript
+// Before
+client.emit('custom_message', { action: 'notify', payload: {...} });
+
+// After
+client.emit('custom_message', { event: 'notify', payload: {...} });
+```
+
+## 3. Server-Side Integrations
+
+Python extensions that call `broadcast` or interact directly with the
+WebSocket should send JSON containing `event`:
+
+```python
+await bifrost.broadcast(json.dumps({
+    "event": "broadcast",
+    "data": {"message": "Hello"}
+}))
+```
+
+## 4. Test Checklist
+
+1. Run automated tests: `pytest zTestSuite/zComm_Test.py`
+2. Exercise GUI flows (zDisplay) to ensure input responses still round-trip.
+3. Validate cache controls (`get_schema`, `clear_cache`, `cache_stats`).
+4. Execute representative zDispatch commands via the client.
+
+## 5. Deprecation Timeline
+
+* `bifrost_bridge.py` remains temporarily for backwards compatibility but now
+  issues a `DeprecationWarning`.
+* Future releases will remove the legacy bridge once ecosystem clients have
+  migrated to the event protocol.
+
+## Resources
+
+* [`MESSAGE_PROTOCOL.md`](MESSAGE_PROTOCOL.md) – Canonical event definitions.
+* [`README.md`](README.md) – Architectural overview and component map.
+* `Documentation/Bifrost_Modular_Architecture.md` – Historical context for the
+  modular refactor.

--- a/zCLI/subsystems/zComm/zComm_modules/zBifrost/__init__.py
+++ b/zCLI/subsystems/zComm/zComm_modules/zBifrost/__init__.py
@@ -5,6 +5,6 @@ zBifrost WebSocket Bridge Module
 Secure WebSocket server with authentication and origin validation.
 """
 
-from .bifrost_bridge import zBifrost, broadcast, start_socket_server
+from .bifrost_bridge_modular import zBifrost, broadcast, start_socket_server
 
 __all__ = ['zBifrost', 'broadcast', 'start_socket_server']

--- a/zCLI/subsystems/zComm/zComm_modules/zBifrost/bifrost_bridge.py
+++ b/zCLI/subsystems/zComm/zComm_modules/zBifrost/bifrost_bridge.py
@@ -1,5 +1,18 @@
 # zCLI/subsystems/zComm/zComm_modules/zBifrost/bifrost_bridge.py
-"""Secure WebSocket server with authentication and origin validation."""
+"""Secure WebSocket server with authentication and origin validation.
+
+DEPRECATED: This legacy implementation remains temporarily for backward
+compatibility. New code should import from ``bifrost_bridge_modular``
+instead, which provides the event-driven architecture used by zDisplay.
+"""
+
+import warnings
+
+warnings.warn(
+    "bifrost_bridge.py is deprecated. Use bifrost_bridge_modular.py instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 try:
     from websockets import serve as ws_serve  # Standard import

--- a/zCLI/subsystems/zComm/zComm_modules/zBifrost/bridge_modules/__init__.py
+++ b/zCLI/subsystems/zComm/zComm_modules/zBifrost/bridge_modules/__init__.py
@@ -6,11 +6,21 @@ from .cache_manager import CacheManager
 from .authentication import AuthenticationManager
 from .message_handler import MessageHandler
 from .connection_info import ConnectionInfoManager
+from .events import (
+    ClientEvents,
+    CacheEvents,
+    DiscoveryEvents,
+    DispatchEvents,
+)
 
 __all__ = [
     'CacheManager',
     'AuthenticationManager',
     'MessageHandler',
-    'ConnectionInfoManager'
+    'ConnectionInfoManager',
+    'ClientEvents',
+    'CacheEvents',
+    'DiscoveryEvents',
+    'DispatchEvents',
 ]
 

--- a/zCLI/subsystems/zComm/zComm_modules/zBifrost/bridge_modules/events/__init__.py
+++ b/zCLI/subsystems/zComm/zComm_modules/zBifrost/bridge_modules/events/__init__.py
@@ -1,0 +1,13 @@
+"""Event handler packages for zBifrost modular bridge."""
+
+from .client_events import ClientEvents
+from .cache_events import CacheEvents
+from .discovery_events import DiscoveryEvents
+from .dispatch_events import DispatchEvents
+
+__all__ = [
+    "ClientEvents",
+    "CacheEvents",
+    "DiscoveryEvents",
+    "DispatchEvents",
+]

--- a/zCLI/subsystems/zComm/zComm_modules/zBifrost/bridge_modules/events/cache_events.py
+++ b/zCLI/subsystems/zComm/zComm_modules/zBifrost/bridge_modules/events/cache_events.py
@@ -1,0 +1,31 @@
+"""Cache event handlers for zBifrost."""
+
+
+class CacheEvents:
+    """Handle schema and query cache related events."""
+
+    def __init__(self, bridge):
+        self.bridge = bridge
+        self.logger = bridge.logger
+
+    async def handle_get_schema(self, ws, data):
+        """Return schema information for requested model."""
+        handled = await self.bridge.message_handler.handle_get_schema(ws, data)
+        if handled:
+            self.logger.debug("[CacheEvents] [OK] Served schema for %s", data.get("model"))
+        return handled
+
+    async def handle_clear_cache(self, ws, data):
+        """Clear caches and send confirmation payload."""
+        handled = await self.bridge.message_handler.handle_clear_cache(ws)
+        if handled:
+            self.logger.info("[CacheEvents] All caches cleared via event")
+        return handled
+
+    async def handle_cache_stats(self, ws, data):
+        """Send current cache statistics."""
+        return await self.bridge.message_handler.handle_cache_stats(ws)
+
+    async def handle_set_cache_ttl(self, ws, data):
+        """Update default TTL for query cache."""
+        return await self.bridge.message_handler.handle_set_cache_ttl(ws, data)

--- a/zCLI/subsystems/zComm/zComm_modules/zBifrost/bridge_modules/events/client_events.py
+++ b/zCLI/subsystems/zComm/zComm_modules/zBifrost/bridge_modules/events/client_events.py
@@ -1,0 +1,25 @@
+"""Client event handlers for zBifrost."""
+
+
+class ClientEvents:
+    """Handle client-focused events (input, connection state)."""
+
+    def __init__(self, bridge):
+        self.bridge = bridge
+        self.logger = bridge.logger
+
+    async def handle_input_response(self, ws, data):
+        """Route GUI input responses back to zDisplay."""
+        await self.bridge.message_handler.handle_input_response(data)
+        return True
+
+    async def handle_connection_info(self, ws, data):
+        """Send current connection details to requesting client."""
+        payload = dict(data or {})
+        auth_info = self.bridge.auth.get_client_info(ws)
+        if auth_info:
+            payload["auth"] = auth_info
+        handled = await self.bridge.message_handler.handle_connection_info(ws, payload)
+        if handled:
+            self.logger.debug("[ClientEvents] [OK] Dispatched connection info snapshot")
+        return handled

--- a/zCLI/subsystems/zComm/zComm_modules/zBifrost/bridge_modules/events/discovery_events.py
+++ b/zCLI/subsystems/zComm/zComm_modules/zBifrost/bridge_modules/events/discovery_events.py
@@ -1,0 +1,23 @@
+"""Discovery event handlers for zBifrost."""
+
+
+class DiscoveryEvents:
+    """Expose discovery and introspection features to clients."""
+
+    def __init__(self, bridge):
+        self.bridge = bridge
+        self.logger = bridge.logger
+
+    async def handle_discover(self, ws, data):
+        """Return available models metadata."""
+        handled = await self.bridge.message_handler.handle_discover(ws)
+        if handled:
+            self.logger.debug("[DiscoveryEvents] [OK] Discovery event served")
+        return handled
+
+    async def handle_introspect(self, ws, data):
+        """Return metadata for a single model."""
+        handled = await self.bridge.message_handler.handle_introspect(ws, data)
+        if handled:
+            self.logger.debug("[DiscoveryEvents] [OK] Introspection for %s", data.get("model"))
+        return handled

--- a/zCLI/subsystems/zComm/zComm_modules/zBifrost/bridge_modules/events/dispatch_events.py
+++ b/zCLI/subsystems/zComm/zComm_modules/zBifrost/bridge_modules/events/dispatch_events.py
@@ -1,0 +1,13 @@
+"""Dispatch event handlers for zBifrost."""
+
+
+class DispatchEvents:
+    """Handle zDispatch command routing events."""
+
+    def __init__(self, bridge):
+        self.bridge = bridge
+        self.logger = bridge.logger
+
+    async def handle_dispatch(self, ws, data):
+        """Execute zDispatch command coming from client."""
+        return await self.bridge.message_handler.handle_dispatch(ws, data, self.bridge.broadcast)


### PR DESCRIPTION
## Summary
- expose the modular zBifrost bridge by default and deprecate the legacy bridge shim
- add dedicated client/cache/discovery/dispatch event handler packages and central event routing
- document the standardized event protocol and migration path while updating the JS client and docs to emit the `event` field
- extend zComm tests to cover the event map and legacy action inference

## Testing
- pytest zTestSuite/zComm_Test.py

------
https://chatgpt.com/codex/tasks/task_b_68fcfe8860a4832bb5481d2e99560d71