### PR TITLE
Add documentation audit tracker for repository assets

### DIFF
--- a/docs_audit.md
+++ b/docs_audit.md
@@ -1,0 +1,114 @@
+# Documentation Audit Tracker
+
+| Path | Format | Classification | Notes |
+|------|--------|----------------|-------|
+| AGENT.md | md | authoritative | Contributor instructions for working with the repo; must stay current. |
+| COVERAGE_ANALYSIS_LAYER0.md | md | outdated | Week 2.3 coverage snapshot that predates later refactors. |
+| DECORATOR_FIX_SUMMARY.md | md | outdated | Historical summary of a specific fix; superseded by implementation. |
+| FINAL_TEST_FIX_SUMMARY.md | md | outdated | Patch notes for a past testing issue, no longer maintained. |
+| LAYER2_REORDER_COMPLETE.md | md | outdated | Completion report for an older milestone. |
+| LAYER2_REORDER_PLAN.md | md | outdated | Planning notes for work already finished. |
+| OS_GETCWD_FIX_SUMMARY.md | md | outdated | Legacy bug fix summary for reference only. |
+| PLAN_UPDATE_MULTI_APP_AND_OAUTH.md | md | outdated | Planning memo from earlier roadmap iteration. |
+| README.md | md | authoritative | Primary overview and quickstart for the project. |
+| TYPE_HINTS_GUIDE.md | md | outdated | Week 1.3 implementation notes that no longer reflect current scope. |
+| WEEK_1.3_SUMMARY.md | md | outdated | Sprint summary retained for history. |
+| WEEK_1.4_AUDIT.md | md | outdated | Audit findings for a prior sprint. |
+| WEEK_1.4_SUMMARY.md | md | outdated | Sprint recap now stale. |
+| WEEK_1.5_SUMMARY.md | md | outdated | Sprint recap now stale. |
+| WEEK_1.6_COMPLETE.md | md | outdated | Completion report for an earlier milestone. |
+| WEEK_1.6_PHASE_1_SUMMARY.md | md | outdated | Phase report no longer active. |
+| WEEK_1.6_PHASE_2_SUMMARY.md | md | outdated | Phase report no longer active. |
+| WEEK_1.6_PHASE_3_SUMMARY.md | md | outdated | Phase report no longer active. |
+| WEEK_1.6_PHASE_4_SUMMARY.md | md | outdated | Phase report no longer active. |
+| WEEK_2.1_IMPLEMENTATION_SUMMARY.md | md | outdated | Implementation summary from Week 2.1. |
+| WEEK_6_1_1_IMPLEMENTATION_SUMMARY.md | md | outdated | Implementation summary superseded by newer iterations. |
+| WEEK_6_1_1_SUMMARY.md | md | outdated | Sprint recap no longer current. |
+| WEEK_6_1_2_SUMMARY.md | md | outdated | Sprint recap no longer current. |
+| WEEK_6_2_1_CONFIG_PATHS_REFACTOR.md | md | outdated | Refactor note for a completed task. |
+| WEEK_6_2_2_CONFIG_MACHINE_CLEANUP.md | md | outdated | Cleanup note for a completed task. |
+| WEEK_6_2_3_MACHINE_DETECTORS_REFACTOR.md | md | outdated | Refactor note for a completed task. |
+| WEEK_6_2_5_SESSION_REFACTOR_SUMMARY.md | md | outdated | Refactor summary from earlier iteration. |
+| WEEK_6_2_ZCONFIG_AUDIT.md | md | outdated | Audit doc for past sprint. |
+| WEEK_6_3_6_6_THREE_TIER_AUTH_COMPLETE.md | md | outdated | Completion summary for past auth milestone. |
+| WEEK_6_3_6_6a_SESSION_REDESIGN.md | md | outdated | Session redesign plan from older effort. |
+| WEEK_6_3_6_6b_ZAUTH_ENHANCEMENT.md | md | outdated | Auth enhancement plan already delivered. |
+| WEEK_6_3_6_6c_BRIDGE_AUTH_IMPLEMENTATION.md | md | outdated | Implementation log for completed work. |
+| WEEK_6_3_6_6d_TESTING_VALIDATION.md | md | outdated | Validation checklist for past milestone. |
+| WEEK_6_3_6_7_CACHE_SECURITY_COMPLETE.md | md | outdated | Cache security milestone recap. |
+| WEEK_6_3_6_8_MESSAGES_COMPLETE.md | md | outdated | Messaging milestone recap. |
+| WEEK_6_4_10_DATA_IMPLEMENTATION.md | md | outdated | Implementation notes for past data milestone. |
+| WEEK_6_4_1_DELEGATES_AUDIT.md | md | outdated | Delegate audit document from old sprint. |
+| WEEK_6_4_1_DELEGATES_IMPLEMENTATION.md | md | outdated | Implementation plan already executed. |
+| WEEK_6_4_1_DELEGATES_MODULAR_REFACTORING.md | md | outdated | Refactoring plan already executed. |
+| WEEK_6_4_5_PRIMITIVES_AUDIT.md | md | outdated | Audit notes for completed milestone. |
+| WEEK_6_4_5_PRIMITIVES_IMPLEMENTATION.md | md | outdated | Implementation recap for past milestone. |
+| WEEK_6_4_6_EVENTS_AUDIT.md | md | outdated | Audit notes for completed milestone. |
+| WEEK_6_4_6_EVENTS_IMPLEMENTATION.md | md | outdated | Implementation recap for past milestone. |
+| WEEK_6_4_7_OUTPUTS_IMPLEMENTATION.md | md | outdated | Implementation recap for past milestone. |
+| WEEK_6_4_8_SIGNALS_IMPLEMENTATION.md | md | outdated | Implementation recap for past milestone. |
+| WEEK_6_4_PROGRESS_FILE_REMOVAL.md | md | outdated | Progress tracking document now stale. |
+| WEEK_6_4_ROOT_AUDIT.md | md | outdated | Audit notes for completed milestone. |
+| WEEK_6_4_ROOT_IMPLEMENTATION.md | md | outdated | Implementation recap for past milestone. |
+| ZDISPLAY_NAMING_CONVENTION_COMPLETE.md | md | outdated | Naming convention update already rolled in. |
+| ZSERVER_IMPLEMENTATION_SUMMARY.md | md | outdated | Implementation summary for legacy release. |
+| ZUTILS_AUDIT.md | md | outdated | Audit notes for zUtils milestone. |
+| ZUTILS_PHASE1_COMPLETE.md | md | outdated | Completion summary for zUtils phase 1. |
+| ZUTILS_PHASE2_COMPLETE.md | md | outdated | Completion summary for zUtils phase 2. |
+| ZUTILS_PHASE3_COMPLETE.md | md | outdated | Completion summary for zUtils phase 3. |
+| ZWIZARD_AUDIT.md | md | outdated | Audit notes for zWizard milestone. |
+| plan_styles.css | css | replace/merge | Styling asset tied to legacy plan pages; consolidate with active documentation assets. |
+| plan_week_6.1_core_utils.html | html | outdated | Week 6 planning artifact archived for reference. |
+| plan_week_6.2_zconfig.html | html | outdated | Week 6 planning artifact archived for reference. |
+| plan_week_6.3_zcomm.html | html | outdated | Week 6 planning artifact archived for reference. |
+| plan_week_6.4_zdisplay.html | html | outdated | Week 6 planning artifact archived for reference. |
+| plan_week_6.5_parser_loader_dialog.html | html | outdated | Week 6 planning artifact archived for reference. |
+| plan_week_6.5_zauth.html | html | outdated | Week 6 planning artifact archived for reference. |
+| plan_week_6.6_zdispatch.html | html | outdated | Week 6 planning artifact archived for reference. |
+| plan_week_6.7_znavigation.html | html | outdated | Week 6 planning artifact archived for reference. |
+| plan_week_6.8_zparser.html | html | outdated | Week 6 planning artifact archived for reference. |
+| plan_week_6.9_zloader.html | html | outdated | Week 6 planning artifact archived for reference. |
+| plan_week_6.10_zfunc.html | html | outdated | Week 6 planning artifact archived for reference. |
+| plan_week_6.11_zdialog.html | html | outdated | Week 6 planning artifact archived for reference. |
+| plan_week_6.12_zopen.html | html | outdated | Week 6 planning artifact archived for reference. |
+| plan_week_6.13_zshell.html | html | outdated | Week 6 planning artifact archived for reference. |
+| plan_week_6.14_zwizard.html | html | outdated | Week 6 planning artifact archived for reference. |
+| plan_week_6.15_zutils.html | html | outdated | Week 6 planning artifact archived for reference. |
+| plan_week_6.16_zdata.html | html | outdated | Week 6 planning artifact archived for reference. |
+| plan_week_6.17_zwalker.html | html | outdated | Week 6 planning artifact archived for reference. |
+| plan_week_6.18_zcli.html | html | outdated | Week 6 planning artifact archived for reference. |
+| plan_week_6.19_verification.html | html | outdated | Week 6 planning artifact archived for reference. |
+| v1.5.4_plan.html | html | outdated | Release plan snapshot that predates current roadmap. |
+| v1.5.4_plan_index.html | html | outdated | Landing page for retired plan set. |
+| Documentation/Auto_Discovery_API.md | md | authoritative | Current feature guide for auto-discovery APIs. |
+| Documentation/Bifrost_Modular_Architecture.md | md | authoritative | Architectural reference for zBifrost modular design. |
+| Documentation/DEFERRED_COVERAGE.md | md | authoritative | Explains intentional coverage deferrals for maintainers. |
+| Documentation/INSTALL.md | md | authoritative | Supported installation procedures. |
+| Documentation/Release/RELEASE_1.5.1.md | md | authoritative | Official release notes for v1.5.1. |
+| Documentation/Release/RELEASE_1.5.2.md | md | authoritative | Official release notes for v1.5.2. |
+| Documentation/Release/RELEASE_1.5.3.md | md | authoritative | Official release notes for v1.5.3. |
+| Documentation/Release/RELEASE_1.5.4.md | md | authoritative | Official release notes for v1.5.4. |
+| Documentation/Release/RELEASE_ZSERVER.md | md | authoritative | Release notes specific to zServer packaging. |
+| Documentation/SEPARATION_CHECKLIST.md | md | authoritative | Checklist still used during reviews. |
+| Documentation/Schema_Caching_Implementation.md | md | authoritative | Current documentation of schema caching behavior. |
+| Documentation/TESTING_GUIDE.md | md | authoritative | Maintained how-to guide for testing workflows. |
+| Documentation/TESTING_STRATEGY.md | md | replace/merge | Substantial overlap with TESTING_GUIDE; should merge to eliminate duplication. |
+| Documentation/zAuth_GUIDE.md | md | authoritative | Official subsystem guide for zAuth. |
+| Documentation/zCLI_GUIDE.md | md | authoritative | Official subsystem guide for zCLI. |
+| Documentation/zComm_GUIDE.md | md | authoritative | Official subsystem guide for zComm. |
+| Documentation/zConfig_GUIDE.md | md | authoritative | Official subsystem guide for zConfig. |
+| Documentation/zData_GUIDE.md | md | authoritative | Official subsystem guide for zData. |
+| Documentation/zDialog_GUIDE.md | md | authoritative | Official subsystem guide for zDialog. |
+| Documentation/zDisplay_GUIDE.md | md | authoritative | Official subsystem guide for zDisplay. |
+| Documentation/zLoader_GUIDE.md | md | authoritative | Official subsystem guide for zLoader. |
+| Documentation/zOpen_GUIDE.md | md | authoritative | Official subsystem guide for zOpen. |
+| Documentation/zParser_GUIDE.md | md | authoritative | Official subsystem guide for zParser. |
+| Documentation/zPath_GUIDE.md | md | authoritative | Official subsystem guide for zPath. |
+| Documentation/zPlugin_GUIDE.md | md | authoritative | Official subsystem guide for zPlugin. |
+| Documentation/zSchema_GUIDE.md | md | authoritative | Official subsystem guide for zSchema. |
+| Documentation/zServer_GUIDE.md | md | authoritative | Official subsystem guide for zServer. |
+| Documentation/zShell_GUIDE.md | md | authoritative | Official subsystem guide for zShell. |
+| Documentation/zUI_GUIDE.md | md | authoritative | Official subsystem guide for zUI. |
+| Documentation/zVaFiles_GUIDE.md | md | authoritative | Official subsystem guide for zVaFiles. |
+| Documentation/zWalker_GUIDE.md | md | authoritative | Official subsystem guide for zWalker. |
+| Documentation/zWizard_GUIDE.md | md | authoritative | Official subsystem guide for zWizard. |


### PR DESCRIPTION
## Summary
- add a docs_audit tracker cataloging documentation files in the root and Documentation directories
- record the authoritative, outdated, and merge-needed classifications to guide future cleanup

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690dc855ea4c832b902d43ff07f0615c)