### PR TITLE
Add zDisplay primitives micro-step demos

### DIFF
--- a/Demos/Layer_1/zDisplay_Demo/README.md
+++ b/Demos/Layer_1/zDisplay_Demo/README.md
@@ -15,7 +15,16 @@ These micro-step demos introduce you to zDisplay's complete rendering capabiliti
 
 ---
 
-### **Level 1: Basic Outputs & Signals** (2 demos)
+### **Level 1: Output Primitives** (3 demos)
+**Foundation** - Lowest-level write calls for raw text
+
+| Demo | What It Shows |
+|------|---------------|
+| `output/Level_1_Primitives/write_raw.py` | `write_raw()` – raw output with **no** newline |
+| `output/Level_1_Primitives/write_line.py` | `write_line()` – auto-newline per call |
+| `output/Level_1_Primitives/write_block.py` | `write_block()` – multi-line block output |
+
+### **Level 1 (continued): Basic Outputs & Signals** (2 demos)
 **Core Rendering** - Headers, text, and feedback
 
 | Demo | What It Shows |
@@ -77,8 +86,14 @@ These micro-step demos introduce you to zDisplay's complete rendering capabiliti
 cd Level_0_Hello
 python hello_display.py
 
-# Level 1: Basic Outputs
-cd ../Level_1_Outputs_Signals
+# Level 1A: Output Primitives
+cd ../output/Level_1_Primitives
+python write_raw.py
+python write_line.py
+python write_block.py
+
+# Level 1B: Basic Outputs
+cd ../../Level_1_Outputs_Signals
 python outputs_simple.py
 python signals_basic.py
 

--- a/Demos/Layer_1/zDisplay_Demo/output/Level_1_Primitives/README.md
+++ b/Demos/Layer_1/zDisplay_Demo/output/Level_1_Primitives/README.md
@@ -1,0 +1,49 @@
+# Level 1: zDisplay Primitives (Raw Output)
+
+**<span style="color:#8FBE6D">Fastest possible path from "nothing" to on-screen text.</span>**
+
+These micro-step tutorials mirror the style of **zConfig** and **zComm**: each file teaches **one tiny concept** you can copy/paste into your own code.
+
+## Files
+- **`write_raw.py`** — Raw output with **no newline**. Perfect for inline status like `Loading...`.
+- **`write_line.py`** — Adds the newline for you. Great for log-style output.
+- **`write_block.py`** — Sends **multiple lines at once** while preserving your formatting.
+
+## How to Run
+```bash
+cd Demos/Layer_1/zDisplay_Demo/output/Level_1_Primitives
+python write_raw.py
+python write_line.py
+python write_block.py
+```
+
+## Micro-Steps
+
+> <span style="color:#8FBE6D">**Step 1: write_raw()**</span>
+- Create `z = zCLI({"logger": "PROD"})`
+- Call `z.display.write_raw("Downloading...")`
+- **What you see:** Text streams on the same line—no newline added.
+
+> <span style="color:#8FBE6D">**Step 2: write_line()**</span>
+- Reuse the same zCLI instance
+- Call `z.display.write_line("Each call is a new line")`
+- **What you see:** Every call ends cleanly with a newline—no manual `\n` required.
+
+> <span style="color:#8FBE6D">**Step 3: write_block()**</span>
+- Build a multi-line string
+- Call `z.display.write_block(block_text)`
+- **What you see:** Your block prints exactly as written, with a trailing newline handled for you.
+
+## Why Start Here?
+- These primitives are the **foundation** for all higher-level zDisplay events (signals, tables, progress).
+- They work in **Terminal** and **zBifrost** (browser) modes automatically—no extra setup.
+- Keeping logger set to **`PROD`** keeps the output focused on the demo itself.
+
+## Next Steps
+- Move to **Level 1: Basic Outputs & Signals** in `../Level_1_Outputs_Signals` once you’re comfortable with the primitives.
+- Use these primitives alongside headers, signals, and tables to build richer output flows.
+
+---
+**Time:** ~5 minutes total (1 minute per micro-step)  
+**Difficulty:** Beginner  
+**Version:** 1.5.5

--- a/Demos/Layer_1/zDisplay_Demo/output/Level_1_Primitives/write_block.py
+++ b/Demos/Layer_1/zDisplay_Demo/output/Level_1_Primitives/write_block.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""
+Level 1: Primitives - write_block()
+==================================
+
+Goal:
+    Send multiple lines at once while zDisplay handles the trailing newline.
+    Great for small banners, status summaries, or preformatted text blocks.
+
+Run:
+    python Demos/Layer_1/zDisplay_Demo/output/Level_1_Primitives/write_block.py
+"""
+
+from zCLI import zCLI
+
+
+def run_demo():
+    """Demonstrate multi-line output with write_block()."""
+    z = zCLI({"logger": "PROD"})
+
+    print()
+    print("=== Level 1C: write_block() - Multi-line output ===")
+    print()
+
+    block = """Deployment Summary
+- Host: localhost
+- Mode: Terminal
+- Status: Ready to render"""
+
+    z.display.write_block(block)
+
+    print("write_block() keeps the formatting you supply and ends with a clean newline.")
+    print()
+
+
+if __name__ == "__main__":
+    run_demo()

--- a/Demos/Layer_1/zDisplay_Demo/output/Level_1_Primitives/write_line.py
+++ b/Demos/Layer_1/zDisplay_Demo/output/Level_1_Primitives/write_line.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""
+Level 1: Primitives - write_line()
+=================================
+
+Goal:
+    Use write_line() to write single lines that always end with a newline.
+    Perfect for log-style output where each entry should start on its own line.
+
+Run:
+    python Demos/Layer_1/zDisplay_Demo/output/Level_1_Primitives/write_line.py
+"""
+
+from zCLI import zCLI
+
+
+def run_demo():
+    """Demonstrate write_line() adding newlines for you."""
+    z = zCLI({"logger": "PROD"})
+
+    print()
+    print("=== Level 1B: write_line() - Automatic newline ===")
+    print()
+
+    z.display.write_line("1) Each call becomes its own line")
+    z.display.write_line("2) No need to append \n manually")
+    z.display.write_line("3) Works the same in Terminal or zBifrost")
+
+    print("Notice how the terminal spacing stays clean without manual newline management.")
+    print()
+
+
+if __name__ == "__main__":
+    run_demo()

--- a/Demos/Layer_1/zDisplay_Demo/output/Level_1_Primitives/write_raw.py
+++ b/Demos/Layer_1/zDisplay_Demo/output/Level_1_Primitives/write_raw.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""
+Level 1: Primitives - write_raw()
+=================================
+
+Goal:
+    See how write_raw() prints text immediately with no newline.
+    Perfect for inline updates ("Loading..."), progress ticks, or
+    combining manual spacing with higher-level display events.
+
+Run:
+    python Demos/Layer_1/zDisplay_Demo/output/Level_1_Primitives/write_raw.py
+"""
+
+from zCLI import zCLI
+
+
+def run_demo():
+    """Demonstrate raw output without automatic newlines."""
+    z = zCLI({"logger": "PROD"})
+
+    print()
+    print("=== Level 1A: write_raw() - No newline added ===")
+    print()
+
+    z.display.write_raw("Downloading")
+    z.display.write_raw("...")
+    z.display.write_raw(" still working")
+    z.display.write_raw(" (all on one line)")
+
+    # Finish the line so the terminal prompt returns cleanly
+    z.display.write_raw("\n")
+
+    print("Tip: write_raw() is great for inline status without forcing a newline.")
+    print()
+
+
+if __name__ == "__main__":
+    run_demo()

--- a/Documentation/zDialog_GUIDE.md
+++ b/Documentation/zDialog_GUIDE.md
@@ -4,6 +4,10 @@
 
 **zDialog** is zCLI's **Interactive Form/Dialog Subsystem**. It handles form rendering, data collection, auto-validation against zSchema, and submission processing with mode-agnostic support for both Terminal and Bifrost (GUI) environments.
 
+### Start Here: First Tutorials
+- **Display primitives first.** Run the new micro-step demos in `Demos/Layer_1/zDisplay_Demo/output/Level_1_Primitives/` (write_raw, write_line, write_block) to see how raw text flows through zDisplay before adding form-specific rendering.
+- These three scripts mirror the zConfig/zComm tutorial style—quick, copy/paste-ready steps—and form the entry point for this guide before you move into zDialog-specific YAML forms.
+
 ### Executive Summary
 zDialog enables developers to create interactive forms declaratively using YAML, with automatic validation against data schemas and intelligent placeholder injection. Forms work seamlessly in both command-line (Terminal) and web-based (Bifrost) modes. The subsystem handles complex workflows like multi-field data collection, nested placeholder resolution, and submission routing—all while maintaining zCLI's pure declarative paradigm.
 


### PR DESCRIPTION
## Summary
- add Level 1 output primitive tutorials covering write_raw, write_line, and write_block
- include a micro-step README and integrate the new primitives into the zDisplay demo index
- point the zDialog guide to the new primitives as the first tutorials

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6925a40d9800832bbb4aae680828a281)